### PR TITLE
Improve readme and pypi package appearance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.3.8
+-----
 * Unit tests
 * Releases with good versions
 
@@ -80,6 +81,7 @@
 -----
 * remote-pull: now pulls without syncing the trees
 * remote-quick: when you want to execute a command without syncing the trees
+
 1.1.2
 ---
 * More fixes to md5 generation (verified to work on mac and linux)
@@ -88,7 +90,7 @@
 1.1.1
 ---
 * Robust in finding appropriate md5 utility
- 
+
 1.1
 ---
 * Added remote-pull

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include CHANGELOG
 include LICENSE
+include README.md
+include src/remote/py.typed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-![Release](https://github.com/shirshanka/remote/workflows/Create%20Release/badge.svg)
-
-remote
+Remote
 ======
 
+[![Code Quality](https://github.com/remote-cli/remote/workflows/Python%20Code%20Quality/badge.svg)](https://github.com/remote-cli/remote/actions?query=branch%3Amaster+workflow%3A%22Python+Code+Quality%22)
+[![pypi](https://img.shields.io/pypi/v/remote-exec.svg)](https://pypi.org/project/remote-exec)
+[![versions](https://img.shields.io/pypi/pyversions/remote-exec.svg)](https://github.com/remote-cli/remote)
+[![license](https://img.shields.io/github/license/remote-cli/remote.svg)](https://github.com/remote-cli/remote/blob/master/LICENSE)
+
 Work with remote hosts seamlessly
-Remote uses rsync and ssh to create a seamless working environment from a local directory to remote directories. 
+Remote uses rsync and ssh to create a seamless working environment from a local directory to remote directories.
 Most used features are:
-* Remotely execute commands from any sub-directory. 
+* Remotely execute commands from any sub-directory.
 * Drop into remote interactive sessions.
 * Fire off parallel remote commands on multiple hosts.
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,19 @@ def get_version():
         return f.readline().strip()
 
 
+def get_long_description():
+    root = os.path.dirname(__file__)
+    with open(os.path.join(root, "README.md")) as f:
+        description = f.read()
+
+    description += "\n\nChangelog\n=========\n\n"
+
+    with open(os.path.join(root, "CHANGELOG")) as f:
+        description += f.read()
+
+    return description
+
+
 setuptools.setup(
     name="remote-exec",
     version=get_version(),
@@ -16,9 +29,32 @@ setuptools.setup(
     author="Shirshanka Das",
     license="BSD-2-CLAUSE",
     description="A CLI to sync codebases and execute commands remotely",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: Unix",
+        "Operating System :: POSIX :: Linux",
+        "Environment :: Console",
+        "Environment :: MacOS X",
+        "Topic :: Software Development",
+    ],
+    python_requires=">=3.6",
     package_dir={"": "src"},
-    packages=setuptools.find_namespace_packages(where="src"),
+    packages=["remote"],
     include_package_data=True,
+    package_data={"remote": ["py.typed"]},
     entry_points={
         "console_scripts": [
             "remote = remote.entrypoints:remote",


### PR DESCRIPTION
This PR adds some new badges to Readme file and does some other change to make pypi page of the project better:

- copies readme and changelog to long_description so it will be displayed on pypi page
- adds package metadata
- adds py.typed file to tell consumers that this module supports type annotations
- fixes some markdown formatiing issues