### PR TITLE
Add toml use_relative_remote_paths configuration option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.4.0
+-----
+* TOML config support
+* .gitignore files can be used as a source for sync ignore
+
 1.3.8
 -----
 * Unit tests

--- a/src/remote/configuration/classic.py
+++ b/src/remote/configuration/classic.py
@@ -5,7 +5,6 @@ This configuration may have three meaningful files:
 .remoteindex (optional) - information about which connection from options above to use
 .remoteignore (optional) - information about files that should be ignore when syncing files
 """
-import hashlib
 import os
 import re
 
@@ -17,7 +16,7 @@ from typing import Dict, List, Tuple
 from remote.exceptions import ConfigurationError
 
 from . import ConfigurationMedium, RemoteConfig, SyncIgnores, WorkspaceConfig
-from .shared import DEFAULT_REMOTE_ROOT
+from .shared import DEFAULT_REMOTE_ROOT, hash_path
 
 CONFIG_FILE_NAME = ".remote"
 INDEX_FILE_NAME = ".remoteindex"
@@ -233,5 +232,5 @@ class ClassicConfigurationMedium(ConfigurationMedium):
         return (path / CONFIG_FILE_NAME).exists()
 
     def generate_remote_directory(self, config: WorkspaceConfig) -> Path:
-        md5 = hashlib.md5(str(config.root).encode()).hexdigest()
-        return Path(f"{DEFAULT_REMOTE_ROOT}/{config.root.name}_{md5[:8]}")
+        md5 = hash_path(config.root)
+        return Path(f"{DEFAULT_REMOTE_ROOT}/{config.root.name}_{md5}")

--- a/src/remote/configuration/shared.py
+++ b/src/remote/configuration/shared.py
@@ -1,3 +1,11 @@
+import hashlib
+
+from pathlib import Path
+
 DEFAULT_REMOTE_ROOT = ".remotes"
 HOST_REGEX = r"[-\w]+(\.[-\w]+)*"
 PATH_REGEX = r"/?[-.\w\s]+(/[-.\w\s]+)*/?"
+
+
+def hash_path(path: Path):
+    return hashlib.md5(str(path).encode()).hexdigest()[:8]

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -65,8 +65,9 @@ def _add_remote_host(config: WorkspaceConfig, connection: str):
 
     # Check if we can connect to the remote host and create a directory there
     workspace = SyncedWorkspace.from_config(config, config.root, index)
-    code = workspace.execute(f"mkdir -p {workspace.remote.directory}", simple=True, raise_on_error=False)
-    if code != 0:
+    try:
+        workspace.create_remote()
+    except RemoteError:
         click.secho(f"Failed to create {workspace.remote.directory} on remote host {remote_host}", fg="yellow")
         click.secho("Please check if host is accessible via SSH", fg="yellow")
         sys.exit(1)

--- a/src/remote/util.py
+++ b/src/remote/util.py
@@ -67,7 +67,7 @@ def rsync(
     """
 
     logger.info("Sync files from %s to %s", src, dst)
-    args = ["rsync", "-rlpmchz", "--copy-unsafe-links", "-e", "ssh -q", "--force"]
+    args = ["rsync", "-arlpmchz", "--copy-unsafe-links", "-e", "ssh -q", "--force"]
     if info:
         args.append("-i")
     if verbose:

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -125,7 +125,18 @@ cd {self.remote_working_dir}
         src = f"{self.local_root}/"
         dst = f"{self.remote.host}:{self.remote.directory}"
         ignores = self.ignores.compile_push_ignores()
-        rsync(src, dst, info=info, verbose=verbose, dry_run=dry_run, mirror=mirror, excludes=ignores)
+        # If remote directory structure is deep and it was deleted, we need an rsync-path to recreate it before copying
+        extra_args = ["--rsync-path", f"mkdir -p {self.remote.directory} && rsync"]
+        rsync(
+            src,
+            dst,
+            info=info,
+            verbose=verbose,
+            dry_run=dry_run,
+            mirror=mirror,
+            excludes=ignores,
+            extra_args=extra_args,
+        )
 
     def pull(self, info=False, verbose=False, dry_run=False, subpath=None):
         """Pull remote files to local workspace
@@ -150,3 +161,7 @@ cd {self.remote_working_dir}
     def clear_remote(self):
         """Remove remote directory"""
         self.execute(f"rm -rf {self.remote.directory}", simple=True)
+
+    def create_remote(self):
+        """Remove remote directory"""
+        self.execute(f"mkdir -p {self.remote.directory}", simple=True)

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -365,11 +365,13 @@ def test_remote(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
                     "--force",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
                     "--exclude-from",
                     ANY,
                     f"{tmp_workspace}/",
@@ -397,7 +399,7 @@ echo test >> .file
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
@@ -429,11 +431,13 @@ def test_remote_execution_fail(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
                     "--force",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
                     "--exclude-from",
                     ANY,
                     f"{tmp_workspace}/",
@@ -461,7 +465,7 @@ echo 'test >> .file'
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
@@ -491,11 +495,13 @@ def test_remote_sync_fail(mock_run, tmp_workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
             "--force",
+            "--rsync-path",
+            "mkdir -p .remotes/myproject && rsync",
             "--exclude-from",
             ANY,
             f"{tmp_workspace}/",
@@ -572,12 +578,14 @@ def test_remote_push(mock_run, tmp_workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
             "--force",
             "-i",
+            "--rsync-path",
+            "mkdir -p .remotes/myproject && rsync",
             "--exclude-from",
             ANY,
             f"{tmp_workspace}/",
@@ -605,12 +613,14 @@ def test_remote_push_mass(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
                     "--force",
                     "-i",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
                     "--exclude-from",
                     ANY,
                     f"{tmp_workspace}/",
@@ -622,12 +632,14 @@ def test_remote_push_mass(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
                     "--force",
                     "-i",
+                    "--rsync-path",
+                    "mkdir -p other-directory && rsync",
                     "--exclude-from",
                     ANY,
                     f"{tmp_workspace}/",
@@ -652,7 +664,7 @@ def test_remote_pull(mock_run, tmp_workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
@@ -683,7 +695,7 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
@@ -698,7 +710,7 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -74,7 +74,7 @@ def test_rsync_respects_all_options(mock_run):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -72,11 +72,13 @@ def test_push(mock_run, workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
             "--force",
+            "--rsync-path",
+            "mkdir -p remote/dir && rsync",
             f"{workspace.local_root}/",
             f"{workspace.remote.host}:{workspace.remote.directory}",
         ],
@@ -93,7 +95,7 @@ def test_pull(mock_run, workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
@@ -116,7 +118,7 @@ def test_pull_with_subdir(mock_run, workspace):
     mock_run.assert_called_once_with(
         [
             "rsync",
-            "-rlpmchz",
+            "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
             "ssh -q",
@@ -164,11 +166,13 @@ def test_execute_and_sync(mock_run, workspace):
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",
                     "--force",
+                    "--rsync-path",
+                    "mkdir -p remote/dir && rsync",
                     f"{workspace.local_root}/",
                     f"{workspace.remote.host}:{workspace.remote.directory}",
                 ],
@@ -195,7 +199,7 @@ echo 'Hello World!'
             call(
                 [
                     "rsync",
-                    "-rlpmchz",
+                    "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
                     "ssh -q",


### PR DESCRIPTION
This PR:

- introduces `use_relative_remote_paths` global option. If this option is on, paths for remote workspaces will be generated as relative paths for the home directory. Eg, if you have a local workspace in `~/projects/foo/bar`, it will generate remote path `.remotes/projects/foo/bar`. It should make easier for developers to navigate .remotes directory
- adds `include_vsc_ignore_patterns` option that adds all .gitignore entries to ignore patterns
- add `-a` to default rsync options to speed up the sync
- uses `--rsync-path` trick from https://stackoverflow.com/questions/1636889/rsync-how-can-i-configure-it-to-create-target-directory-on-server/22908437#22908437 to ensure remote directory exists before copying files
- adds a function to save global config
