### PR TITLE
Add -o BatchMode=yes to ssh to fail the command when password is required

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.4.1
+-----
+* Fail ssh and rsync when password is requested by adding -o BatchMode=yes
+
 1.4.0
 -----
 * TOML config support

--- a/src/remote/util.py
+++ b/src/remote/util.py
@@ -67,7 +67,7 @@ def rsync(
     """
 
     logger.info("Sync files from %s to %s", src, dst)
-    args = ["rsync", "-arlpmchz", "--copy-unsafe-links", "-e", "ssh -q", "--force"]
+    args = ["rsync", "-arlpmchz", "--copy-unsafe-links", "-e", "ssh -q -o BatchMode=yes", "--force"]
     if info:
         args.append("-i")
     if verbose:
@@ -127,7 +127,7 @@ def ssh(host: str, command: str, dry_run: bool = False, raise_on_error: bool = T
 
     :returns: exit code of remote command or 255 if connection didn't go through
     """
-    subprocess_command = ["ssh", "-tKq", host, command]
+    subprocess_command = ["ssh", "-tKq", "-o", "BatchMode=yes", host, command]
     logger.info("Executing:\n%s %s %s <<EOS\n%sEOS", *subprocess_command)
     if dry_run:
         return 0

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -106,7 +106,9 @@ def test_remote_init(mock_run, tmp_path):
     assert "Created remote directory at test-host.example.com:.remotes/myproject_" in result.output
     assert "Remote is configured and ready to use" in result.output
 
-    mock_run.assert_called_once_with(["ssh", "-tKq", "test-host.example.com", ANY], stdin=ANY, stdout=ANY, stderr=ANY)
+    mock_run.assert_called_once_with(
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "test-host.example.com", ANY], stdin=ANY, stdout=ANY, stderr=ANY
+    )
 
     assert (subdir / CONFIG_FILE_NAME).exists()
     assert (subdir / CONFIG_FILE_NAME).read_text().startswith("test-host.example.com:.remotes/myproject_")
@@ -144,7 +146,7 @@ Remote is configured and ready to use
     )
 
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "test-host.example.com", "mkdir -p .path/test.dir/_test-dir"],
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "test-host.example.com", "mkdir -p .path/test.dir/_test-dir"],
         stdin=ANY,
         stdout=ANY,
         stderr=ANY,
@@ -259,7 +261,7 @@ def test_remote_add_adds_host(mock_run, tmp_workspace):
     assert (tmp_workspace / CONFIG_FILE_NAME).read_text() == f"{TEST_CONFIG}\nhost:directory\n"
 
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "host", "mkdir -p directory"], stdin=ANY, stdout=ANY, stderr=ANY,
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "host", "mkdir -p directory"], stdin=ANY, stdout=ANY, stderr=ANY,
     )
 
 
@@ -368,7 +370,7 @@ def test_remote(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--rsync-path",
                     "mkdir -p .remotes/myproject && rsync",
@@ -384,6 +386,8 @@ def test_remote(mock_run, tmp_workspace):
                 [
                     "ssh",
                     "-tKq",
+                    "-o",
+                    "BatchMode=yes",
                     TEST_HOST,
                     """if [ -f .remotes/myproject/.remoteenv ]; then
   source .remotes/myproject/.remoteenv 2>/dev/null 1>/dev/null
@@ -402,7 +406,7 @@ echo test >> .file
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--exclude-from",
                     ANY,
@@ -434,7 +438,7 @@ def test_remote_execution_fail(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--rsync-path",
                     "mkdir -p .remotes/myproject && rsync",
@@ -450,6 +454,8 @@ def test_remote_execution_fail(mock_run, tmp_workspace):
                 [
                     "ssh",
                     "-tKq",
+                    "-o",
+                    "BatchMode=yes",
                     TEST_HOST,
                     """if [ -f .remotes/myproject/.remoteenv ]; then
   source .remotes/myproject/.remoteenv 2>/dev/null 1>/dev/null
@@ -468,7 +474,7 @@ echo 'test >> .file'
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--exclude-from",
                     ANY,
@@ -498,7 +504,7 @@ def test_remote_sync_fail(mock_run, tmp_workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "--rsync-path",
             "mkdir -p .remotes/myproject && rsync",
@@ -525,6 +531,8 @@ def test_remote_quick(mock_run, tmp_workspace):
         [
             "ssh",
             "-tKq",
+            "-o",
+            "BatchMode=yes",
             TEST_HOST,
             """if [ -f .remotes/myproject/.remoteenv ]; then
   source .remotes/myproject/.remoteenv 2>/dev/null 1>/dev/null
@@ -552,6 +560,8 @@ def test_remote_quick_execution_fail(mock_run, tmp_workspace):
         [
             "ssh",
             "-tKq",
+            "-o",
+            "BatchMode=yes",
             TEST_HOST,
             """if [ -f .remotes/myproject/.remoteenv ]; then
   source .remotes/myproject/.remoteenv 2>/dev/null 1>/dev/null
@@ -581,7 +591,7 @@ def test_remote_push(mock_run, tmp_workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "-i",
             "--rsync-path",
@@ -616,7 +626,7 @@ def test_remote_push_mass(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "-i",
                     "--rsync-path",
@@ -635,7 +645,7 @@ def test_remote_push_mass(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "-i",
                     "--rsync-path",
@@ -667,7 +677,7 @@ def test_remote_pull(mock_run, tmp_workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "-i",
             "--exclude-from",
@@ -698,7 +708,7 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "-i",
                     f"{TEST_HOST}:{TEST_DIR}/build",
@@ -713,7 +723,7 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "-i",
                     f"{TEST_HOST}:{TEST_DIR}/dist",
@@ -736,5 +746,5 @@ def test_remote_delete(mock_run, tmp_workspace):
 
     assert result.exit_code == 0
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", TEST_HOST, f"rm -rf {TEST_DIR}"], stdin=ANY, stdout=ANY, stderr=ANY,
+        ["ssh", "-tKq", "-o", "BatchMode=yes", TEST_HOST, f"rm -rf {TEST_DIR}"], stdin=ANY, stdout=ANY, stderr=ANY,
     )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -77,7 +77,7 @@ def test_rsync_respects_all_options(mock_run):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "-i",
             "-v",
@@ -137,7 +137,7 @@ def test_ssh(mock_run):
 
     assert code == 0
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "my-host.example.com", "exit 0"], stdout=ANY, stderr=ANY, stdin=ANY
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "my-host.example.com", "exit 0"], stdout=ANY, stderr=ANY, stdin=ANY
     )
 
 
@@ -150,7 +150,10 @@ def test_ssh_raises_exception(mock_run, returncode, error):
         ssh("my-host.example.com", f"exit {returncode}")
 
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "my-host.example.com", f"exit {returncode}"], stdout=ANY, stderr=ANY, stdin=ANY
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "my-host.example.com", f"exit {returncode}"],
+        stdout=ANY,
+        stderr=ANY,
+        stdin=ANY,
     )
 
 
@@ -164,7 +167,10 @@ def test_ssh_returns_error_code_if_configured(mock_run, returncode):
 
     assert code == returncode
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "my-host.example.com", f"exit {returncode}"], stdout=ANY, stderr=ANY, stdin=ANY
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "my-host.example.com", f"exit {returncode}"],
+        stdout=ANY,
+        stderr=ANY,
+        stdin=ANY,
     )
 
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -57,7 +57,7 @@ def test_clear_remote_workspace(mock_run, workspace):
 
     # clear should always delete remote root regardless of what the workign dir is
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", workspace.remote.host, f"rm -rf {workspace.remote.directory}"],
+        ["ssh", "-tKq", "-o", "BatchMode=yes", workspace.remote.host, f"rm -rf {workspace.remote.directory}"],
         stderr=ANY,
         stdin=ANY,
         stdout=ANY,
@@ -75,7 +75,7 @@ def test_push(mock_run, workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "--rsync-path",
             "mkdir -p remote/dir && rsync",
@@ -98,7 +98,7 @@ def test_pull(mock_run, workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             "--exclude-from",
             ANY,
@@ -121,7 +121,7 @@ def test_pull_with_subdir(mock_run, workspace):
             "-arlpmchz",
             "--copy-unsafe-links",
             "-e",
-            "ssh -q",
+            "ssh -q -o BatchMode=yes",
             "--force",
             f"{workspace.remote.host}:{workspace.remote.directory}/some-path",
             f"{workspace.local_root}/some-path",
@@ -140,6 +140,8 @@ def test_execute(mock_run, workspace):
         [
             "ssh",
             "-tKq",
+            "-o",
+            "BatchMode=yes",
             workspace.remote.host,
             """\
 if [ -f remote/dir/.remoteenv ]; then
@@ -169,7 +171,7 @@ def test_execute_and_sync(mock_run, workspace):
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--rsync-path",
                     "mkdir -p remote/dir && rsync",
@@ -183,6 +185,8 @@ def test_execute_and_sync(mock_run, workspace):
                 [
                     "ssh",
                     "-tKq",
+                    "-o",
+                    "BatchMode=yes",
                     workspace.remote.host,
                     """\
 if [ -f remote/dir/.remoteenv ]; then
@@ -202,7 +206,7 @@ echo 'Hello World!'
                     "-arlpmchz",
                     "--copy-unsafe-links",
                     "-e",
-                    "ssh -q",
+                    "ssh -q -o BatchMode=yes",
                     "--force",
                     "--exclude-from",
                     ANY,


### PR DESCRIPTION
ssh and rsync should fail if the password is requested during normal operation since it's the indicator of incorrect configuration.

Testing:
**With correct configuration:**
`(env) jieli$ remote-push`
`<fcst....... src/remote/util.py`

**With wrong configuration:**
`(env) jieli$ remote-push`
`rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(226) [sender=3.1.3]
Failed to sync files betwen /Users/jieli/IdeaProjects/remote-build/openSource/remote/ and jieli-ld1:rdev-exec/IdeaProjects/remote-build/openSource/remote. Is remote host reachable`