### PR TITLE
Leverage --include-from flag of rsync to include files which needs to be synced.

### DIFF
--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -19,32 +19,32 @@ class RemoteConfig:
 
 
 @dataclass
-class SyncIgnores:
-    """Patterns used to ignore files when syncing with remote location"""
+class SyncRules:
+    """Patterns used to either ignore or exclude files when syncing with remote location"""
 
-    # patterns to ignore while pulling from remote
+    # patterns to either ignore or exclude while pulling from remote
     pull: List[str]
-    # patterns to ignore while pushing from local
+    # patterns to either ignore or exclude while pushing from local
     push: List[str]
-    # patterns to ignore while transferring files in both directions
+    # patterns to either ignore or exclude while transferring files in both directions
     both: List[str]
 
     def __post_init__(self):
         self.trim()
 
-    def compile_push_ignores(self):
+    def compile_push(self):
         result = set()
         result.update(self.push)
         result.update(self.both)
         return sorted(result)
 
-    def compile_pull_ignores(self):
+    def compile_pull(self):
         result = set()
         result.update(self.pull)
         result.update(self.both)
         return sorted(result)
 
-    def add_ignores(self, ignores: List[str]):
+    def add(self, ignores: List[str]):
         new_ignores = set()
         new_ignores.update(ignores)
         new_ignores.update(self.both)
@@ -59,41 +59,7 @@ class SyncIgnores:
         return not (self.pull or self.push or self.both)
 
     @classmethod
-    def new(cls) -> "SyncIgnores":
-        return cls([], [], [])
-
-
-@dataclass
-class SyncIncludes:
-    """Patterns used to include files when syncing with remote location"""
-
-    # patterns to include while pulling from remote
-    pull: List[str]
-    # patterns to include while pushing from local
-    push: List[str]
-    # patterns to include while transferring files in both directions
-    both: List[str]
-
-    def compile_push_includes(self):
-        result = set()
-        result.update(self.push)
-        result.update(self.both)
-        return sorted(result)
-
-    def compile_pull_includes(self):
-        result = set()
-        result.update(self.pull)
-        result.update(self.both)
-        return sorted(result)
-
-    def add_includes(self, ignores: List[str]):
-        new_includes = set()
-        new_includes.update(ignores)
-        new_includes.update(self.both)
-        self.both = sorted(new_includes)
-
-    @classmethod
-    def new(cls) -> "SyncIncludes":
+    def new(cls) -> "SyncRules":
         return cls([], [], [])
 
 
@@ -108,18 +74,14 @@ class WorkspaceConfig:
     # index of default remote host connection
     default_configuration: int
     # patterns to ignore while syncing the workspace
-    ignores: SyncIgnores
+    ignores: SyncRules
     # patterns to include while syncing the workspace
-    includes: SyncIncludes
+    includes: SyncRules
 
     @classmethod
     def empty(cls, root: Path) -> "WorkspaceConfig":
         return cls(
-            root=root,
-            configurations=[],
-            default_configuration=0,
-            ignores=SyncIgnores.new(),
-            includes=SyncIncludes.new(),
+            root=root, configurations=[], default_configuration=0, ignores=SyncRules.new(), includes=SyncRules.new(),
         )
 
     def add_remote_host(

--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -20,13 +20,13 @@ class RemoteConfig:
 
 @dataclass
 class SyncRules:
-    """Patterns used to either ignore or exclude files when syncing with remote location"""
+    """Patterns used by rsync to forcefully exclude or include files while syncyng with remote location"""
 
-    # patterns to either ignore or exclude while pulling from remote
+    # patterns used by rsync to forcefully exclude or include files while pulling from remote
     pull: List[str]
-    # patterns to either ignore or exclude while pushing from local
+    # patterns used by rsync to forcefully exclude or include files while pushing from local
     push: List[str]
-    # patterns to either ignore or exclude while transferring files in both directions
+    # patterns used by rsync to forcefully exclude or include while transferring files in both directions
     both: List[str]
 
     def __post_init__(self):

--- a/src/remote/configuration/classic.py
+++ b/src/remote/configuration/classic.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Tuple
 
 from remote.exceptions import ConfigurationError
 
-from . import ConfigurationMedium, RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
+from . import ConfigurationMedium, RemoteConfig, SyncRules, WorkspaceConfig
 from .shared import DEFAULT_REMOTE_ROOT, hash_path
 
 CONFIG_FILE_NAME = ".remote"
@@ -126,10 +126,10 @@ def _postprocess(ignores):
         raise ConfigurationError(
             f"{IGNORE_FILE_NAME} file has unexpected sections: {', '.join(ignores.keys())}. Please remove them"
         )
-    return SyncIgnores(pull=pull, push=push, both=both)
+    return SyncRules(pull=pull, push=push, both=both)
 
 
-def load_ignores(workspace_root: Path) -> SyncIgnores:
+def load_ignores(workspace_root: Path) -> SyncRules:
     ignores: Dict[str, List[str]] = defaultdict(list)
     ignores["both"].extend(BASE_IGNORES)
 
@@ -173,7 +173,7 @@ def save_general_config(config_file: Path, configurations: List[RemoteConfig]):
             f.write("\n")
 
 
-def save_ignores(config_file: Path, ignores: SyncIgnores):
+def save_ignores(config_file: Path, ignores: SyncRules):
     ignores.both.extend(BASE_IGNORES)
     ignores.trim()
 
@@ -221,7 +221,7 @@ class ClassicConfigurationMedium(ConfigurationMedium):
             configurations=configurations,
             default_configuration=configuration_index,
             ignores=ignores,
-            includes=SyncIncludes.new(),
+            includes=SyncRules.new(),
         )
 
     def save_config(self, config: WorkspaceConfig) -> None:

--- a/src/remote/configuration/classic.py
+++ b/src/remote/configuration/classic.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Tuple
 
 from remote.exceptions import ConfigurationError
 
-from . import ConfigurationMedium, RemoteConfig, SyncIgnores, WorkspaceConfig
+from . import ConfigurationMedium, RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
 from .shared import DEFAULT_REMOTE_ROOT, hash_path
 
 CONFIG_FILE_NAME = ".remote"
@@ -199,7 +199,7 @@ def save_index(config_file: Path, index: int):
 
 
 class ClassicConfigurationMedium(ConfigurationMedium):
-    """A medium class that knows hot to load and save the 'classical' workspace configuration.
+    """A medium class that knows how to load and save the 'classical' workspace configuration.
 
     This configuration may have three meaningful files:
     .remote (required) - information about the connection options
@@ -221,6 +221,7 @@ class ClassicConfigurationMedium(ConfigurationMedium):
             configurations=configurations,
             default_configuration=configuration_index,
             ignores=ignores,
+            includes=SyncIncludes.new(),
         )
 
     def save_config(self, config: WorkspaceConfig) -> None:

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -304,9 +304,9 @@ class TomlConfigurationMedium(ConfigurationMedium):
         )
 
         includes = SyncRules(
-            pull=merged_config.pull.include if merged_config.pull and merged_config.pull.include else [],
-            push=merged_config.push.include if merged_config.push and merged_config.push.include else [],
-            both=merged_config.both.include if merged_config.both and merged_config.both.include else [],
+            pull=merged_config.pull.include if merged_config.pull else [],
+            push=merged_config.push.include if merged_config.push else [],
+            both=merged_config.both.include if merged_config.both else [],
         )
 
         return WorkspaceConfig(

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -73,7 +73,7 @@ from pydantic import BaseModel, Field, ValidationError, validator
 
 from remote.exceptions import ConfigurationError
 
-from . import ConfigurationMedium, RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
+from . import ConfigurationMedium, RemoteConfig, SyncRules, WorkspaceConfig
 from .shared import DEFAULT_REMOTE_ROOT, HOST_REGEX, hash_path
 
 WORKSPACE_CONFIG = ".remote.toml"
@@ -297,13 +297,13 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     directory=connection.directory or self._generate_remote_directory_from_path(workspace_root),
                 )
             )
-        ignores = SyncIgnores(
+        ignores = SyncRules(
             pull=_get_exclude(merged_config.pull, workspace_root),
             push=_get_exclude(merged_config.push, workspace_root),
             both=_get_exclude(merged_config.both, workspace_root) + [WORKSPACE_CONFIG],
         )
 
-        includes = SyncIncludes(
+        includes = SyncRules(
             pull=merged_config.pull.include if merged_config.pull and merged_config.pull.include else [],
             push=merged_config.push.include if merged_config.push and merged_config.push.include else [],
             both=merged_config.both.include if merged_config.both and merged_config.both.include else [],
@@ -322,7 +322,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
 
         For now, this method don't have any smart merging of extension arguments.
         """
-        config.ignores.add_ignores([WORKSPACE_CONFIG])
+        config.ignores.add([WORKSPACE_CONFIG])
 
         local_config = LocalConfig()
         local_config.hosts = []

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -136,7 +136,7 @@ def remote_ignore(ignore: List[str]):
     """
 
     config = load_cwd_workspace_config()
-    config.ignores.add_ignores(ignore)
+    config.ignores.add(ignore)
     save_config(config)
 
 

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Union
 
-from .configuration import RemoteConfig, SyncIgnores, WorkspaceConfig
+from .configuration import RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
 from .configuration.discovery import load_cwd_workspace_config
 from .util import prepare_shell_command, rsync, ssh
 
@@ -23,6 +23,8 @@ class SyncedWorkspace:
     remote_working_dir: Path
     # sync ignore file patterns
     ignores: SyncIgnores
+    # sync include file patterns
+    includes: SyncIncludes
 
     @classmethod
     def from_config(
@@ -41,7 +43,11 @@ class SyncedWorkspace:
         remote_working_dir = remote_config.directory / working_dir
 
         return cls(
-            local_root=config.root, remote=remote_config, remote_working_dir=remote_working_dir, ignores=config.ignores,
+            local_root=config.root,
+            remote=remote_config,
+            remote_working_dir=remote_working_dir,
+            ignores=config.ignores,
+            includes=config.includes,
         )
 
     @classmethod
@@ -125,6 +131,7 @@ cd {self.remote_working_dir}
         src = f"{self.local_root}/"
         dst = f"{self.remote.host}:{self.remote.directory}"
         ignores = self.ignores.compile_push_ignores()
+        includes = self.includes.compile_push_includes()
         # If remote directory structure is deep and it was deleted, we need an rsync-path to recreate it before copying
         extra_args = ["--rsync-path", f"mkdir -p {self.remote.directory} && rsync"]
         rsync(
@@ -134,6 +141,7 @@ cd {self.remote_working_dir}
             verbose=verbose,
             dry_run=dry_run,
             mirror=mirror,
+            includes=includes,
             excludes=ignores,
             extra_args=extra_args,
         )
@@ -156,7 +164,8 @@ cd {self.remote_working_dir}
         src = f"{self.remote.host}:{self.remote.directory}/"
         dst = str(self.local_root)
         ignores = self.ignores.compile_pull_ignores()
-        rsync(src, dst, info=info, verbose=verbose, dry_run=dry_run, excludes=ignores)
+        includes = self.includes.compile_pull_includes()
+        rsync(src, dst, info=info, verbose=verbose, includes=includes, dry_run=dry_run, excludes=ignores)
 
     def clear_remote(self):
         """Remove remote directory"""

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Union
 
-from .configuration import RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
+from .configuration import RemoteConfig, SyncRules, WorkspaceConfig
 from .configuration.discovery import load_cwd_workspace_config
 from .util import prepare_shell_command, rsync, ssh
 
@@ -22,9 +22,9 @@ class SyncedWorkspace:
     # remote directory to use as working directory, relative to users home directory
     remote_working_dir: Path
     # sync ignore file patterns
-    ignores: SyncIgnores
+    ignores: SyncRules
     # sync include file patterns
-    includes: SyncIncludes
+    includes: SyncRules
 
     @classmethod
     def from_config(
@@ -130,8 +130,8 @@ cd {self.remote_working_dir}
         """
         src = f"{self.local_root}/"
         dst = f"{self.remote.host}:{self.remote.directory}"
-        ignores = self.ignores.compile_push_ignores()
-        includes = self.includes.compile_push_includes()
+        ignores = self.ignores.compile_push()
+        includes = self.includes.compile_push()
         # If remote directory structure is deep and it was deleted, we need an rsync-path to recreate it before copying
         extra_args = ["--rsync-path", f"mkdir -p {self.remote.directory} && rsync"]
         rsync(
@@ -163,8 +163,8 @@ cd {self.remote_working_dir}
 
         src = f"{self.remote.host}:{self.remote.directory}/"
         dst = str(self.local_root)
-        ignores = self.ignores.compile_pull_ignores()
-        includes = self.includes.compile_pull_includes()
+        ignores = self.ignores.compile_pull()
+        includes = self.includes.compile_pull()
         rsync(src, dst, info=info, verbose=verbose, includes=includes, dry_run=dry_run, excludes=ignores)
 
     def clear_remote(self):

--- a/test/configuration/test_classic.py
+++ b/test/configuration/test_classic.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from remote.configuration import RemoteConfig, SyncIgnores
+from remote.configuration import RemoteConfig, SyncRules
 from remote.configuration.classic import (
     CONFIG_FILE_NAME,
     IGNORE_FILE_NAME,
@@ -180,7 +180,7 @@ def test_medium_load_minimal_config(tmp_path):
         host="test-host.example.com", directory=Path("remote/dir"), shell="sh", shell_options=""
     )
     # Ignore is always pre-populated even if it's empy in FS
-    assert config.ignores == SyncIgnores(pull=[], push=[], both=[CONFIG_FILE_NAME, IGNORE_FILE_NAME, INDEX_FILE_NAME])
+    assert config.ignores == SyncRules(pull=[], push=[], both=[CONFIG_FILE_NAME, IGNORE_FILE_NAME, INDEX_FILE_NAME])
 
 
 def test_medium_load_old_fashioned_ignore_config(tmp_path):
@@ -196,7 +196,7 @@ def test_medium_load_old_fashioned_ignore_config(tmp_path):
         host="test-host.example.com", directory=Path("remote/dir"), shell="sh", shell_options=""
     )
     # Ignore is always pre-populated even if it's empy in FS
-    assert config.ignores == SyncIgnores(
+    assert config.ignores == SyncRules(
         pull=[], push=[], both=["build", ".git", "*.pyc", CONFIG_FILE_NAME, IGNORE_FILE_NAME, INDEX_FILE_NAME]
     )
 
@@ -243,7 +243,7 @@ build
         RemoteConfig(host="other-host.example.com", directory=Path("other/dir"), shell="bash", shell_options="options"),
         RemoteConfig(host="third-host.example.com", directory=Path(".remote/dir"), shell="zsh", shell_options=""),
     ]
-    assert config.ignores == SyncIgnores(
+    assert config.ignores == SyncRules(
         pull=["src/generated"],
         push=[".git", "*.pyc", "__pycache__"],
         both=["build", CONFIG_FILE_NAME, IGNORE_FILE_NAME, INDEX_FILE_NAME],

--- a/test/configuration/test_configuration.py
+++ b/test/configuration/test_configuration.py
@@ -1,17 +1,17 @@
 from pathlib import Path
 
-from remote.configuration import RemoteConfig, SyncIgnores, WorkspaceConfig
+from remote.configuration import RemoteConfig, SyncRules, WorkspaceConfig
 
 
 def test_empty_ignore():
     # new ignores object is created empty
-    ignores = SyncIgnores.new()
+    ignores = SyncRules.new()
     assert not ignores.pull
     assert not ignores.push
     assert not ignores.both
     assert ignores.is_empty()
-    assert not ignores.compile_push_ignores()
-    assert not ignores.compile_pull_ignores()
+    assert not ignores.compile_push()
+    assert not ignores.compile_pull()
 
     # if we add something it is not empty anymore
     ignores.pull.append("my_pattern")
@@ -20,14 +20,14 @@ def test_empty_ignore():
 
 def test_ignores_compilation():
     # Each collection should extend from both when compiling
-    ignores = SyncIgnores(push=["push_1", "push_2"], pull=["pull_1", "both_1"], both=["both_1", "both_2"])
-    assert ignores.compile_pull_ignores() == ["both_1", "both_2", "pull_1"]
-    assert ignores.compile_push_ignores() == ["both_1", "both_2", "push_1", "push_2"]
+    ignores = SyncRules(push=["push_1", "push_2"], pull=["pull_1", "both_1"], both=["both_1", "both_2"])
+    assert ignores.compile_pull() == ["both_1", "both_2", "pull_1"]
+    assert ignores.compile_push() == ["both_1", "both_2", "push_1", "push_2"]
 
 
 def test_check_adding_patter_extends_both():
-    ignores = SyncIgnores(push=["push_1", "push_2"], pull=["pull_1", "both_1"], both=["both_1", "both_3"])
-    ignores.add_ignores(["both_2"])
+    ignores = SyncRules(push=["push_1", "push_2"], pull=["pull_1", "both_1"], both=["both_1", "both_3"])
+    ignores.add(["both_2"])
     assert ignores.pull == ["both_1", "pull_1"]
     assert ignores.push == ["push_1", "push_2"]
     assert ignores.both == ["both_1", "both_2", "both_3"]

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from remote.configuration import RemoteConfig, SyncIgnores, SyncIncludes, WorkspaceConfig
+from remote.configuration import RemoteConfig, SyncRules, WorkspaceConfig
 from remote.configuration.shared import hash_path
 from remote.configuration.toml import (
     DEFAULT_REMOTE_ROOT,
@@ -319,8 +319,8 @@ exclude = ["build"]
                     RemoteConfig(host="other-host.example.com", directory=Path("my-remotes/foo/bar")),
                 ],
                 default_configuration=1,
-                ignores=SyncIgnores(pull=["src/generated"], push=[".git", "env"], both=["build", ".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=["env"], both=[]),
+                ignores=SyncRules(pull=["src/generated"], push=[".git", "env"], both=["build", ".remote.toml"]),
+                includes=SyncRules(pull=[], push=["env"], both=[]),
             ),
         ),
         # Settings from local config overwrite global ones
@@ -356,8 +356,8 @@ include =["env"]
                 root=Path("/root/foo/bar"),
                 configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
                 default_configuration=0,
-                ignores=SyncIgnores(pull=["src/generated"], push=[".git", "env"], both=[".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=["env"], both=["env"]),
+                ignores=SyncRules(pull=["src/generated"], push=[".git", "env"], both=[".remote.toml"]),
+                includes=SyncRules(pull=[], push=["env"], both=["env"]),
             ),
         ),
         # Settings from local config extend and overwrite global ones. Defaults collision is resolved
@@ -400,10 +400,10 @@ exclude = []
                     RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace")),
                 ],
                 default_configuration=1,
-                ignores=SyncIgnores(
+                ignores=SyncRules(
                     pull=["src/generated"], push=[".git", "env", "extend", "push"], both=[".remote.toml"]
                 ),
-                includes=SyncIncludes(pull=[], push=["env", "push"], both=[]),
+                includes=SyncRules(pull=[], push=["env", "push"], both=[]),
             ),
         ),
         # No global config
@@ -423,8 +423,8 @@ include = ["env"]
                 root=Path("/root/foo/bar"),
                 configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
                 default_configuration=0,
-                ignores=SyncIgnores(pull=[], push=["extend", "push"], both=[".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=["env"], both=[]),
+                ignores=SyncRules(pull=[], push=["extend", "push"], both=[".remote.toml"]),
+                includes=SyncRules(pull=[], push=["env"], both=[]),
             ),
         ),
         # No global config at all, but there are some extends in local
@@ -447,8 +447,8 @@ exclude = []
                 root=Path("/root/foo/bar"),
                 configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
                 default_configuration=0,
-                ignores=SyncIgnores(pull=[], push=["extend", "push"], both=[".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=["env"], both=[]),
+                ignores=SyncRules(pull=[], push=["extend", "push"], both=[".remote.toml"]),
+                includes=SyncRules(pull=[], push=["env"], both=[]),
             ),
         ),
         # No global config and no default set (first is default implicitely)
@@ -467,8 +467,8 @@ include = ["env"]
                 root=Path("/root/foo/bar"),
                 configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
                 default_configuration=0,
-                ignores=SyncIgnores(pull=[], push=["extend", "push"], both=[".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=["env"], both=[]),
+                ignores=SyncRules(pull=[], push=["extend", "push"], both=[".remote.toml"]),
+                includes=SyncRules(pull=[], push=["env"], both=[]),
             ),
         ),
         # No local config, global config has no directory and supports relative remote paths
@@ -491,8 +491,8 @@ include = [".git"]
                 root=Path("/root/foo/bar"),
                 configurations=[RemoteConfig(host="test-host.example.com", directory=Path("remote/foo/bar"))],
                 default_configuration=0,
-                ignores=SyncIgnores(pull=[], push=["extend", "push"], both=[".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=[".git"], both=[]),
+                ignores=SyncRules(pull=[], push=["extend", "push"], both=[".remote.toml"]),
+                includes=SyncRules(pull=[], push=[".git"], both=[]),
             ),
         ),
     ],
@@ -548,8 +548,8 @@ host = "test-host.example.com"
             )
         ],
         default_configuration=0,
-        ignores=SyncIgnores(pull=[], push=[], both=[".remote.toml"]),
-        includes=SyncIncludes(pull=[], push=[], both=[]),
+        ignores=SyncRules(pull=[], push=[], both=[".remote.toml"]),
+        includes=SyncRules(pull=[], push=[], both=[]),
     )
 
 
@@ -600,12 +600,12 @@ pattern_two
         root=Path("/root/foo/bar"),
         configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
         default_configuration=0,
-        ignores=SyncIgnores(
+        ignores=SyncRules(
             pull=["*.pattern", "pattern_two"],
             push=[".git", "env"],
             both=["build", ".remote.toml", "*.pattern", "pattern_two"],
         ),
-        includes=SyncIncludes(pull=[], push=[], both=[]),
+        includes=SyncRules(pull=[], push=[], both=[]),
     )
 
 
@@ -714,8 +714,8 @@ def test_medium_is_workspace_root(mock_home):
                     RemoteConfig(host="other-host.example.com", directory=Path(".remotes/other-workspace")),
                 ],
                 default_configuration=1,
-                ignores=SyncIgnores(pull=["src/generated"], push=[".git", "env"], both=["build", ".remote.toml"]),
-                includes=SyncIncludes(pull=[], push=[], both=[]),
+                ignores=SyncRules(pull=["src/generated"], push=[".git", "env"], both=["build", ".remote.toml"]),
+                includes=SyncRules(pull=[], push=[], both=[]),
             ),
             """\
 [[hosts]]


### PR DESCRIPTION
This PR introduces a configuration setting  **includes**  in **TomlConfigurationMedium** to add include patterns while syncing files. 
Uses rysnc --include-from to include patterns while syncing.