### PR TITLE
Propagate labels to remote config

### DIFF
--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -18,6 +18,8 @@ class RemoteConfig:
     shell_options: str = ""
     # whether remote machine supports gssapi-* auth or not
     supports_gssapi: bool = True
+    # Add label to identify remote
+    label: Optional[str] = None
 
 
 @dataclass
@@ -87,10 +89,15 @@ class WorkspaceConfig:
         )
 
     def add_remote_host(
-        self, host: str, directory: Path, shell: Optional[str] = None, shell_options: Optional[str] = None
+        self,
+        host: str,
+        directory: Path,
+        shell: Optional[str] = None,
+        shell_options: Optional[str] = None,
+        label: Optional[str] = None,
     ) -> Tuple[bool, int]:
         remote_config = RemoteConfig(
-            host=host, directory=directory, shell=shell or "sh", shell_options=shell_options or "",
+            host=host, directory=directory, shell=shell or "sh", shell_options=shell_options or "", label=label
         )
         for num, cfg in enumerate(self.configurations):
             if cfg.host == remote_config.host and cfg.directory == remote_config.directory:

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -341,6 +341,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     directory=connection.directory,
                     default=num == config.default_configuration,
                     supports_gssapi_auth=connection.supports_gssapi,
+                    label=connection.label,
                 )
             )
         for key, value in asdict(config.ignores).items():

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -302,6 +302,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     host=connection.host,
                     directory=connection.directory or self._generate_remote_directory_from_path(workspace_root),
                     supports_gssapi=connection.supports_gssapi_auth,
+                    label=connection.label,
                 )
             )
         ignores = SyncRules(

--- a/src/remote/exceptions.py
+++ b/src/remote/exceptions.py
@@ -16,3 +16,7 @@ class ConfigurationError(RemoteError):
 
 class InvalidInputError(RemoteError):
     """Invalid user input is passed from the cli"""
+
+
+class InvalidRemoteHostLabel(RemoteError):
+    """Invalid label is passed to the workspace."""

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -28,17 +28,28 @@ class SyncedWorkspace:
 
     @classmethod
     def from_config(
-        cls, config: WorkspaceConfig, working_dir: Path, config_num: Optional[int] = None
+        cls, config: WorkspaceConfig, working_dir: Path, config_num: Optional[Union[str, int]] = None
     ) -> "SyncedWorkspace":
         """Create a workspace from configuration object
 
         :param config: workspace config
         :param working_dir: a working directory inside the workspace config
-        :param config_num: if present, overrides the default remote host to use
+        :param config_num: if present, and is a string, filters by label, else overrides the default remote host to use the index
         """
         working_dir = working_dir.relative_to(config.root)
         if config_num is None:
             config_num = config.default_configuration
+        elif type(config_num) == str:
+            config_num = next(
+                (
+                    index
+                    for index, remote_config in enumerate(config.configurations)
+                    if remote_config.label == config_num
+                ),
+                config.default_configuration,
+            )
+        else:
+            config_num = config_num
         remote_config = config.configurations[config_num]
         remote_working_dir = remote_config.directory / working_dir
 

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -719,9 +719,9 @@ def test_medium_is_workspace_root(mock_home):
             WorkspaceConfig(
                 root=Path("/root/foo/bar"),
                 configurations=[
-                    RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace")),
+                    RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"), label="foo"),
                     RemoteConfig(
-                        host="other-host.example.com", directory=Path(".remotes/other-workspace"), supports_gssapi=False
+                        host="other-host.example.com", directory=Path(".remotes/other-workspace"), supports_gssapi=False, label="bar"
                     ),
                 ],
                 default_configuration=1,
@@ -733,12 +733,14 @@ def test_medium_is_workspace_root(mock_home):
 host = "test-host.example.com"
 directory = ".remotes/workspace"
 supports_gssapi_auth = true
+label = "foo"
 
 [[hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
 default = true
 supports_gssapi_auth = false
+label = "bar"
 
 [push]
 exclude = [ ".git", "env",]

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -721,7 +721,10 @@ def test_medium_is_workspace_root(mock_home):
                 configurations=[
                     RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"), label="foo"),
                     RemoteConfig(
-                        host="other-host.example.com", directory=Path(".remotes/other-workspace"), supports_gssapi=False, label="bar"
+                        host="other-host.example.com",
+                        directory=Path(".remotes/other-workspace"),
+                        supports_gssapi=False,
+                        label="bar",
                     ),
                 ],
                 default_configuration=1,
@@ -732,15 +735,15 @@ def test_medium_is_workspace_root(mock_home):
 [[hosts]]
 host = "test-host.example.com"
 directory = ".remotes/workspace"
-supports_gssapi_auth = true
 label = "foo"
+supports_gssapi_auth = true
 
 [[hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
 default = true
-supports_gssapi_auth = false
 label = "bar"
+supports_gssapi_auth = false
 
 [push]
 exclude = [ ".git", "env",]

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -299,10 +299,12 @@ remote_root = "my-remotes"
 
 [[hosts]]
 host = "test-host.example.com"
+label = "bar"
 
 [[hosts]]
 host = "other-host.example.com"
 default = true
+label = "foo"
 
 [push]
 exclude = ["env", ".git"]
@@ -318,8 +320,8 @@ exclude = ["build"]
             WorkspaceConfig(
                 root=Path("/root/foo/bar"),
                 configurations=[
-                    RemoteConfig(host="test-host.example.com", directory=Path("my-remotes/foo/bar")),
-                    RemoteConfig(host="other-host.example.com", directory=Path("my-remotes/foo/bar")),
+                    RemoteConfig(host="test-host.example.com", directory=Path("my-remotes/foo/bar",), label="bar"),
+                    RemoteConfig(host="other-host.example.com", directory=Path("my-remotes/foo/bar"), label="foo"),
                 ],
                 default_configuration=1,
                 ignores=SyncRules(pull=["src/generated"], push=[".git", "env"], both=["build", ".remote.toml"]),
@@ -335,6 +337,7 @@ use_relative_remote_paths = true
 [[hosts]]
 host = "other-host.example.com"
 default = true
+label = "bar"
 
 [push]
 exclude = ["env", ".git"]
@@ -349,6 +352,7 @@ exclude = ["build"]
             """\
 [[hosts]]
 host = "test-host.example.com"
+label = "foo"
 directory = ".remotes/workspace"
 
 [both]
@@ -357,7 +361,9 @@ include =["env"]
 """,
             WorkspaceConfig(
                 root=Path("/root/foo/bar"),
-                configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
+                configurations=[
+                    RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"), label="foo")
+                ],
                 default_configuration=0,
                 ignores=SyncRules(pull=["src/generated"], push=[".git", "env"], both=[".remote.toml"]),
                 includes=SyncRules(pull=[], push=["env"], both=["env"]),

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -29,9 +29,19 @@ def test_create_workspace_selects_proper_remote_host(workspace_config):
     working_dir = workspace_config.root / "foo" / "bar"
     workspace_config.configurations.append(
         RemoteConfig(
-            host="other-host.example.com", directory=Path("other/dir"), shell="bash", shell_options="some options"
+            host="other-host.example.com",
+            directory=Path("other/dir"),
+            shell="bash",
+            shell_options="some options",
+            label="bar",
         )
     )
+    workspace_config.configurations.append(
+        RemoteConfig(
+            host="foo.example.com", directory=Path("other/dir"), shell="bash", shell_options="some options", label="foo"
+        )
+    )
+
     workspace_config.default_configuration = 1
 
     # workspace should select host from workspace_config.default_configuration
@@ -40,13 +50,22 @@ def test_create_workspace_selects_proper_remote_host(workspace_config):
     assert workspace.remote == workspace_config.configurations[1]
     assert workspace.remote_working_dir == workspace_config.configurations[1].directory / "foo" / "bar"
     assert workspace.ignores == workspace_config.ignores
+    assert workspace.remote.label == "bar"
 
-    # now it should select host from overrid
+    # now it should select host from override
     workspace = SyncedWorkspace.from_config(workspace_config, working_dir, config_num=0)
     assert workspace.local_root == workspace_config.root
     assert workspace.remote == workspace_config.configurations[0]
     assert workspace.remote_working_dir == workspace_config.configurations[0].directory / "foo" / "bar"
     assert workspace.ignores == workspace_config.ignores
+
+    # now it should select from the label passed
+    workspace = SyncedWorkspace.from_config(workspace_config, working_dir, config_num="foo")
+    assert workspace.local_root == workspace_config.root
+    assert workspace.remote == workspace_config.configurations[2]
+    assert workspace.remote_working_dir == workspace_config.configurations[2].directory / "foo" / "bar"
+    assert workspace.ignores == workspace_config.ignores
+    assert workspace_config.configurations[2].label == "foo"
 
 
 @patch("remote.util.subprocess.run")

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytest
 
 from remote.configuration import RemoteConfig
+from remote.exceptions import InvalidRemoteHostLabel
 from remote.workspace import SyncedWorkspace
 
 
@@ -53,19 +54,23 @@ def test_create_workspace_selects_proper_remote_host(workspace_config):
     assert workspace.remote.label == "bar"
 
     # now it should select host from override
-    workspace = SyncedWorkspace.from_config(workspace_config, working_dir, config_num=0)
+    workspace = SyncedWorkspace.from_config(workspace_config, working_dir, remote_host_id=0)
     assert workspace.local_root == workspace_config.root
     assert workspace.remote == workspace_config.configurations[0]
     assert workspace.remote_working_dir == workspace_config.configurations[0].directory / "foo" / "bar"
     assert workspace.ignores == workspace_config.ignores
 
     # now it should select from the label passed
-    workspace = SyncedWorkspace.from_config(workspace_config, working_dir, config_num="foo")
+    workspace = SyncedWorkspace.from_config(workspace_config, working_dir, remote_host_id="foo")
     assert workspace.local_root == workspace_config.root
     assert workspace.remote == workspace_config.configurations[2]
     assert workspace.remote_working_dir == workspace_config.configurations[2].directory / "foo" / "bar"
     assert workspace.ignores == workspace_config.ignores
     assert workspace_config.configurations[2].label == "foo"
+
+    # now it should raise an exception as the label is not present
+    with pytest.raises(InvalidRemoteHostLabel):
+        workspace = SyncedWorkspace.from_config(workspace_config, working_dir, remote_host_id="iamnotpresent")
 
 
 @patch("remote.util.subprocess.run")


### PR DESCRIPTION
In order to choose SyncedWorkspace from labels, the labels needs to be propagated upto RemoteeConfig