### PR TITLE
Update the Readme.md and fix .remoteenv issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,358 @@
-Remote
-======
+# Remote
 
 [![Code Quality](https://github.com/remote-cli/remote/workflows/Python%20Code%20Quality/badge.svg)](https://github.com/remote-cli/remote/actions?query=branch%3Amaster+workflow%3A%22Python+Code+Quality%22)
 [![pypi](https://img.shields.io/pypi/v/remote-exec.svg)](https://pypi.org/project/remote-exec)
 [![versions](https://img.shields.io/pypi/pyversions/remote-exec.svg)](https://github.com/remote-cli/remote)
 [![license](https://img.shields.io/github/license/remote-cli/remote.svg)](https://github.com/remote-cli/remote/blob/master/LICENSE)
 
-Work with remote hosts seamlessly
-Remote uses rsync and ssh to create a seamless working environment from a local directory to remote directories.
-Most used features are:
-* Remotely execute commands from any sub-directory.
-* Drop into remote interactive sessions.
-* Fire off parallel remote commands on multiple hosts.
+The `remote` CLI lets you execute long or computation-heavy tasks (e.g., compilation)
+on a powerful remote host while you are working on the source code locally.
+This process is known as a remote execution or remote build.
 
-Executables and purpose
-* remote-init: set up a local directory to point to a remote directory
-* remote-ignore: set up directories / files to ignore while pushing
-* remote-push: explicitly push local changes remote
-* remote-pull: pull a directory from remote to local
-* remote: execute a command remotely, after first syncing the local tree with the remote tree
-* remote-explain: explain your remote setup, explain what command actually will get run
-* remote-quick: execute a command remotely, without syncing the trees
-* remote-add: add another remote host to the mirror list
-* mremote: execute a remote command on all the hosts, after first syncing the local tree with the remote trees
+After you execute `remote`, it will sync your local workspace to the remote host you selected with `rsync`.
+It will then execute the command on this host using `ssh` and bring all the created/modified files back.
+
+## System Requirements
+
+The CLI supports **Linux** and **Mac OS X** operating systems
+with **Python 3.6 or higher** installed. You can also use it on **Windows**
+if you have [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) configured.
+
+The remote host should also be working on **Linux** or **Mac OS X**.
+
+## Getting Started
+
+### Installing on Mac OS X
+
+If you use Mac OS X, you can install `remote` using [Homebrew](https://brew.sh/)
+from our [custom tap](https://github.com/remote-cli/homebrew-remote):
+
+```bash
+brew install remote-cli/remote/remote
+```
+
+Then, you will always be able to update it to the latest version:
+
+```bash
+brew update remote
+```
+
+### Installing on other systems
+
+`remote` doesn't support any package managers other than `brew` yet. However, it can be manually downloaded
+and installed. To do it, visit https://github.com/remote-cli/remote/releases and download the latest released `-shiv` archive, unpack it to some local directory (e.g., `~/.bin`) and add it to PATH:
+
+```bash
+mkdir -p ~/.bin
+tar -C ~/.bin -xzf ~/Downloads/remote-1.4.5-shiv.tgz
+echo 'export PATH=$PATH:/home/username/.bin/remote/bin' >> ~/.bash_profile
+source ~/.bash_profile
+```
+
+Don't forget to replace the `/home/username` above with the actual path to your home directory.
+
+### Configuring the remote host
+
+`remote` CLI needs to be able to establish a passwordless SSH connection to the remote host.
+Please run `ssh -o BatchMode yes <your-host> echo OK` to confirm that everything is ready for you.
+If this command fails, please go through [SSH guide](https://www.ssh.com/ssh/keygen/) to set up
+SSH keys locally and remotely.
+
+### First run
+
+After you are done with the configuration, switch the working directory to the root of your workspace in
+terminal and run `remote-init` to create a configuration file:
+
+```bash
+cd ~/path/to/workspace
+remote-init remote-host.example.com
+```
+
+This will create a config file named `.remote.toml` in the workspace root
+(`~/path/to/workspace/.remote.toml`). This file controls the remote connection and synchronization options.
+You can read more about this file in the Configuration section of this doc.
+
+After it, you can start using remote:
+
+```bash
+# This will sync workspace and run './gradlew build' remotely
+remote ./gradlew build
+
+# This will forcefully push all local files to the remote machine
+remote-push
+
+# This will bring in ./build directory from the remote machine to local even if
+# the CLI is configured to ignore it
+remote-pull build
+```
+
+## Distribution
+
+`remote`'s distribution comes with a set of executables:
+
+* `remote-init`: set up a local directory to point to a remote directory on a target host
+* `remote-ignore`: set up directories/files to ignore while pushing
+* `remote-push`: explicitly push local changes remote
+* `remote-pull`: pull a directory from remote to local
+* `remote`: execute a command remotely, after first syncing the local tree with the remote tree
+* `remote-explain`: explain your remote setup, explain what command actually will get run
+* `remote-quick`: execute a command remotely without syncing the trees
+* `remote-add`: add another remote host to the mirror list
+* `mremote`: execute a remote command on all the hosts, after first syncing the local tree with the remote trees
+
+You can run each of these commands with `--help` flag to get a list of options and arguments they accept.
+
+## Configuration
+
+Two configuration files control the behavior of `remote`:
+
+* `.remote.toml` is a workspace config that is expected to be placed in the root of every workspace.
+  The `remote` CLI cannot execute any commands remotely until this file is present, or the global config
+  overwrites this with `allow_uninitiated_workspaces` option.
+* `~/.config/remote/defaults.toml` is a global config file. It sets options that affect all the workspaces
+  unless they are overwritten by `.remote.toml` file.
+
+Both configs use [TOML](https://github.com/toml-lang/toml) format.
+
+**Workspace root** is a root directory of the project you're working on.
+It is identified by the `.remote.toml` file. Each time you execute `remote` from workspace root or any of its
+subdirectories, `remote` syncs everything under workspace root with the destination host before running the command.
+
+### Global Configuration File
+
+Global configuration file should be placed in `~/.config/remote/defaults.toml`. This config file is optional
+and the `remote` CLI will work with the default values if it is absent. This is the example of how it looks like:
+
+```toml
+[general]
+allow_uninitiated_workspaces = false
+use_relative_remote_paths = false
+remote_root = ".remotes"
+
+[[hosts]]
+host = "linux-host.example.com"
+label = "linux"
+
+[[hosts]]
+host = "macos-host.example.com"
+port = 2022
+supports_gssapi_auth = false
+default = true
+label = "mac"
+
+[push]
+exclude = [".git"]
+
+[pull]
+exclude = ["src/generated"]
+include = ["build/reports"]
+
+[both]
+include_vsc_ignore_patterns = true
+```
+
+1. `[general]` block controls system-wide behavior for the `remote` CLI.
+
+   Reference:
+
+   * `allow_uninitiated_workspaces` (optional, defaults to `false`) - if this flag is set to `true` and
+     the global config contains at least one remote host, `remote` will treat its current working directory
+     as a workspace root even if it doesn't have `.remote.toml` file in it.
+
+     **Warning:** if this option is on and you run `remote` in the subdirectory of already configured workspace,
+     `remote` will ignore workspaces configuration and treat subdirectory as a separate workspace root.
+
+   * `remote_root` (optional, defaults to `".remotes"`) - a default directory on the remote machine that
+     will be used to store synced workspaces. The path is expected to be relative to the remote user's home
+     directory, so `.remotes` will resolve in `/home/username/.remotes`.
+     If the workspace-level configuration sets the `directory` for a host, this setting will be ignored.
+
+   * `use_relative_remote_paths` (optional, defaults to `false`)
+     * if set to `false` all the workspaces will be stored in the `remote_root` of the target host in a flat
+       structure. Each directory will have a name like `<workspace_name>_<workspace_path_hash>`.
+     * if set to `false`, the remote path will be placed in `remote_root` tree like it was placed in the users
+       home directory tree locally. Some examples:
+       * If local path is `/home/username/projects/work/project_name`, the remote path will be
+         `/home/username/.remotes/projects/work/project_name`
+       * If local path is `/tmp/project_name`, the remote path will be
+         `/home/username/.remotes/tmp/project_name`
+
+2. `[[hosts]]` block lists all the remote hosts available for the workspaces. Used when the workspace
+   configuration doesn't overwrite it.
+
+   You can provide multiple hosts in this block, but only one will be selected when you execute `remote`.
+   It will be either the host that is marked by `default = true` or the first one in the list if no
+   default was set explicitly.
+
+   You can run most of the commands with `--label label|number` or `-l label|number` option to run a
+   command on non-default host. `label` here is the text label you put in the config file, `number` is
+   a number of required host in the hosts list, starting from 1.
+
+   Reference:
+
+   * `host` - a hostname, IP address, or ssh alias of a remote machine that you want to use for remote execution.
+   * `port` (optional, defaults to `22`) - a port used by the ssh daemon on the host.
+   * `supports_gssapi_auth` (optional, defaults to `true`) - `true` if the remote host supports `gssapi-*` auth
+     methods. We recommend disabling it if the ssh connection to the host hangs for some time during establishing.
+   * `default` (optional, defaults to `false`) - `true` if this host should be used by default
+   * `label` (optional) - a text label that later can be used to identify the host when running the `remote` CLI.
+
+3. `[push]`, `[pull]`, and `[both]` blocks control what files are synced from local to a remote machine and back
+   before and after the execution. These blocks are used when the workspace configuration doesn't overwrite them.
+
+   `push` block controls the files that are uploaded from local machine to the remote one. `pull` block controls files that are downloaded from remote machine to local one. `both` block extends previous two.
+
+   Each one of these blocks supports the following options:
+
+   * `exclude` (optional, defaults to empty list) - a list of rsync-style patterns. Every file in the workspace
+     that matches these patterns won't be synced unless it is explicitly specified in `include`.
+   * `include` (optional, defaults to empty list) - a list of rsync-style patterns. Every file in the workspace
+     that matches these patterns will be synced even if it matches the `exclude`.
+   * `include_vsc_ignore_patterns` (optional, defaults to `false`) - if `true` and `.gitignore` is present,
+     all its patterns will be included in the `exclude` list.
+
+### Workspace Configuration File
+
+This is the example of how standalone workspace-level `.remote.toml` configuration file looks like:
+
+```toml
+[[hosts]]
+host = "linux-host.example.com"
+directory = ".remotes/workspace"
+label = "linux"
+supports_gssapi_auth = true
+
+[[hosts]]
+host = "macos-host.example.com"
+port = 2022
+directory = ".remotes/other-workspace"
+supports_gssapi_auth = false
+default = true
+label = "mac"
+
+[push]
+exclude = [".git"]
+
+[pull]
+exclude = ["src/generated"]
+include = ["build/reports"]
+
+[both]
+include_vsc_ignore_patterns = true
+```
+
+All the used blocks here are similar to the ones in the global config file. However, you cannot put
+`[general]` block in this file. Also, you can provide one more option in `[[hosts]]` block:
+
+* `directory` (optional) - a path relative to remote user's home. It will be used to store the workspace's
+  file on the remote machine.
+
+Also, if you set at least one value for any of the blocks in the workspace-level config,
+all the values from this block in the global config will be ignored.
+There is a way to change this behavior. You can use `[extends.*]` blocks to do it.
+
+Here is an example. Imagine, you have a following global config:
+
+```toml
+[[hosts]]
+host = "linux-host.example.com"
+label = "linux"
+default = true
+
+[push]
+exclude = [".git"]
+
+[both]
+include_vsc_ignore_patterns = true
+```
+
+If you want to be able to use the same Linux host in the workspace but you want to add one more and modify some exclude patterns, you can create the following workspace config:
+
+```toml
+[[extends.hosts]]
+host = "mac-host.example.com"
+directory = ".remotes/mac-workspace"
+label = "mac"
+default = true
+
+[extends.push]
+exclude = ["workspace-specific-dir"]
+include = [".git/hooks"]
+
+[both]
+include_vsc_ignore_patterns = false
+```
+
+As you can see, some block names start with `extends.`. This name tells remote to merge the
+workspace and global settings.
+
+There are a few things to note:
+
+* If both workspace-level and global configs define a default host, the workspace-level config wins
+* Hosts ordering is preserver, globally configured hosts always go first.
+* If an option value is a list (e.g. `exclude`), it is extended. Otherwise, the value is overwritten.
+
+### .remoteenv file
+
+Sometimes you will need to do some action each time before you execute some remote command.
+A common example will be to execute `pytest` in the virtual environment: you need to activate it
+first, but the activation state won't be preserved between the `remote` runs.
+
+There are two ways of solving this problem:
+
+1. Running both initiation logic and the command together:
+
+   ```bash
+   remote 'source env/bin/activate && pytest'
+   ```
+
+2. Creating a file called `.remoteenv` in the workspace root. If this file is present, `remote` will
+   always run `source .remoteenv` on the destination host before running the actual command. For example,
+   here is how you can run `remote`'s tests on the other hosts:
+
+   ```bash
+   git clone git@github.com:remote-cli/remote.git
+   cd remote
+   remote-init <remote-host-name>
+   remote python3 -m venv env
+   echo '. env/bin/activate' >> .remoteenv
+
+   # starting from this point all python commands will be executed in virtualenv remotely
+   # This should print virtualenv's python path
+   remote which python
+   remote pip install -e .
+   remote pip install -r test_requirements.txt
+   remote pytest
+   ```
+
+   The `.remoteenv` file is guaranteed to sync to remote machine even if it is excluded by the workspace's
+   `.gitignore` file or other rules.
+
+## Development & Contribution
+
+To bootstrap the development run:
+
+```bash
+git clone git@github.com:remote-cli/remote.git
+cd remote
+python3 -m venv env
+source env/bin/activate
+pip install -e .
+pip install -r test_requirements.txt
+```
+
+After it, you can open the code in any editor or IDE you like. If you prefer VSCode, the project contains the configuration file for it.
+
+Before submitting your pull request, please check it by running:
+
+```bash
+flake8 src test && mypy -p remote && black --check -l 120 src test && isort -rc --check-only src test && pytest
+```
+
+If `black` or `isort` fails, you can fix it using the following command:
+
+```bash
+black -l 120 src test && isort -rc src test
+```
+
+Don't forget to add changed files to your commit after you do it.

--- a/src/remote/configuration/discovery.py
+++ b/src/remote/configuration/discovery.py
@@ -40,7 +40,7 @@ def get_configuration_medium(config: WorkspaceConfig) -> ConfigurationMedium:
             return medium
 
     # If there is no medium found, the config is newly created, so we return a default one
-    return ClassicConfigurationMedium()
+    return TomlConfigurationMedium()
 
 
 def save_config(config: WorkspaceConfig):

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -1,65 +1,7 @@
 """
 This module contains the medium for toml-based config that consists of global and local parts.
 
-The global config is located in ~/.config/remote/defaults.toml and contains some machine-specific
-connection settings that will be used by all workspaces if their own config doesn't overwrite it
-
-    [general]
-    no-config-workspaces = true
-    remote-root = ".remotes"
-
-    [[hosts]]
-    host = "test-host.example.com"
-    directory = ".remotes/workspace"
-    default = true
-
-    [push]
-    # list of exclude patterns in rsync exclude syntax
-    # describes the files and directories that we should exclude from pushing to remote host before execution
-    exclude = ["env", ".git"]
-
-    [pull]
-    # list of exclude patterns in rsync exclude syntax
-    # describes the files and directories that we should exclude from
-    # pulling to local machine from remote host after execution
-    exclude = ["src/generated"]
-
-    [both]
-    # list of exclude patterns in rsync exclude syntax
-    # describes the files and directories that we should exclude from moving in both directions
-    exclude = ["build"]
-
-The workspace config is located in .remote.toml file and contains workspace-specific settings that can overwrite or
-extend global ones:
-
-    [[hosts]]
-    host = "test-host.example.com"
-    directory = ".remotes/workspace"
-
-    [[hosts]]
-    host = "other-host.example.com"
-    directory = ".remotes/other-workspace"
-    default = true
-
-    [push]
-    exclude = ["env", ".git"]
-
-    [pull]
-    exclude = ["src/generated"]
-
-    [both]
-    exclude = ["build"]
-
-Instead of overwriting values, the workspace config can extend some values
-
-    [[extends.hosts]]
-    host = "other-host.example.com"
-    directory = ".remotes/other-workspace"
-    default = true
-
-    [extends.push]
-    exclude = ["workspace-specific-dir"]
-
+See the README.md file for details
 """
 import re
 

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -90,11 +90,13 @@ class SyncedWorkspace:
         return replace(ssh, force_tty=False)
 
     def _generate_command(self, command: str) -> str:
+        relative_path = self.remote_working_dir.relative_to(self.remote.directory)
         return f"""\
-if [ -f {self.remote.directory}/.remoteenv ]; then
-  source {self.remote.directory}/.remoteenv 2>/dev/null 1>/dev/null
+cd {self.remote.directory}
+if [ -f .remoteenv ]; then
+  source .remoteenv
 fi
-cd {self.remote_working_dir}
+cd {relative_path}
 {command}
 """
 
@@ -170,6 +172,7 @@ cd {self.remote_working_dir}
         dst = f"{self.remote.host}:{self.remote.directory}"
         ignores = self.ignores.compile_push()
         includes = self.includes.compile_push()
+        includes.append("/.remoteenv")
         # If remote directory structure is deep and it was deleted, we need an rsync-path to recreate it before copying
         extra_args = ["--rsync-path", f"mkdir -p {self.remote.directory} && rsync"]
         rsync(

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -104,6 +104,8 @@ def test_push(mock_run, workspace):
             "--delete",
             "--rsync-path",
             "mkdir -p remote/dir && rsync",
+            "--include-from",
+            ANY,
             f"{workspace.local_root}/",
             f"{workspace.remote.host}:{workspace.remote.directory}",
         ],
@@ -169,10 +171,11 @@ def test_execute(mock_run, workspace):
             "BatchMode=yes",
             workspace.remote.host,
             """\
-if [ -f remote/dir/.remoteenv ]; then
-  source remote/dir/.remoteenv 2>/dev/null 1>/dev/null
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
 fi
-cd remote/dir/foo/bar
+cd foo/bar
 echo 'Hello World!'
 """,
         ],
@@ -198,10 +201,11 @@ def test_execute_with_port_forwarding(mock_run, workspace):
             "5000:localhost:5005",
             workspace.remote.host,
             """\
-if [ -f remote/dir/.remoteenv ]; then
-  source remote/dir/.remoteenv 2>/dev/null 1>/dev/null
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
 fi
-cd remote/dir/foo/bar
+cd foo/bar
 echo 'Hello World!'
 """,
         ],
@@ -230,6 +234,8 @@ def test_execute_and_sync(mock_run, workspace):
                     "--delete",
                     "--rsync-path",
                     "mkdir -p remote/dir && rsync",
+                    "--include-from",
+                    ANY,
                     f"{workspace.local_root}/",
                     f"{workspace.remote.host}:{workspace.remote.directory}",
                 ],
@@ -244,10 +250,11 @@ def test_execute_and_sync(mock_run, workspace):
                     "BatchMode=yes",
                     workspace.remote.host,
                     """\
-if [ -f remote/dir/.remoteenv ]; then
-  source remote/dir/.remoteenv 2>/dev/null 1>/dev/null
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
 fi
-cd remote/dir/foo/bar
+cd foo/bar
 echo 'Hello World!'
 """,
                 ],
@@ -294,6 +301,8 @@ def test_execute_and_sync_with_port_forwarding(mock_run, workspace):
                     "--delete",
                     "--rsync-path",
                     "mkdir -p remote/dir && rsync",
+                    "--include-from",
+                    ANY,
                     f"{workspace.local_root}/",
                     f"{workspace.remote.host}:{workspace.remote.directory}",
                 ],
@@ -310,10 +319,11 @@ def test_execute_and_sync_with_port_forwarding(mock_run, workspace):
                     "5000:localhost:5005",
                     workspace.remote.host,
                     """\
-if [ -f remote/dir/.remoteenv ]; then
-  source remote/dir/.remoteenv 2>/dev/null 1>/dev/null
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
 fi
-cd remote/dir/foo/bar
+cd foo/bar
 echo 'Hello World!'
 """,
                 ],


### PR DESCRIPTION
This PR:

- add public documentation in the readme.md file
- switches the default configuration backend to TOML files
- fixes the issue with .remoteenv not working as expected
- changes some tests

The readme is easier to read here: https://github.com/remote-cli/remote/tree/readme-docs

Also, readme mentions two features (`--label` option and `port` configuration for a host)