### PR TITLE
Introduce port config entry and --label command line option

### DIFF
--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -20,6 +20,8 @@ class RemoteConfig:
     supports_gssapi: bool = True
     # Add label to identify remote
     label: Optional[str] = None
+    # A SSH port, if it differs from default
+    port: Optional[int] = None
 
 
 @dataclass
@@ -95,9 +97,15 @@ class WorkspaceConfig:
         shell: Optional[str] = None,
         shell_options: Optional[str] = None,
         label: Optional[str] = None,
+        port: Optional[int] = None,
     ) -> Tuple[bool, int]:
         remote_config = RemoteConfig(
-            host=host, directory=directory, shell=shell or "sh", shell_options=shell_options or "", label=label
+            host=host,
+            directory=directory,
+            shell=shell or "sh",
+            shell_options=shell_options or "",
+            label=label,
+            port=port,
         )
         for num, cfg in enumerate(self.configurations):
             if cfg.host == remote_config.host and cfg.directory == remote_config.directory:

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -87,6 +87,7 @@ class ConfigModel(BaseModel):
 
 class ConnectionConfig(ConfigModel):
     host: str
+    port: Optional[int] = Field(default=None, gt=1, le=65535)
     directory: Optional[Path] = None
     default: bool = False
     label: Optional[str] = None
@@ -303,6 +304,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     directory=connection.directory or self._generate_remote_directory_from_path(workspace_root),
                     supports_gssapi=connection.supports_gssapi_auth,
                     label=connection.label,
+                    port=connection.port,
                 )
             )
         ignores = SyncRules(
@@ -342,6 +344,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     default=num == config.default_configuration,
                     supports_gssapi_auth=connection.supports_gssapi,
                     label=connection.label,
+                    port=connection.port,
                 )
             )
         for key, value in asdict(config.ignores).items():

--- a/src/remote/util.py
+++ b/src/remote/util.py
@@ -17,6 +17,8 @@ from .exceptions import RemoteConnectionError, RemoteExecutionError
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SSH_PORT = 22
+
 
 def _temp_file(lines: List[str]) -> Path:
     """Create a temporary file with provided content and return its path
@@ -68,6 +70,7 @@ class Ssh:
     """Ssh configuration class, pregenrates and executes commands remotely"""
 
     host: str
+    port: Optional[int] = None
     force_tty: bool = True
     verbosity_level: VerbosityLevel = VerbosityLevel.QUIET
     use_gssapi_auth: bool = True
@@ -89,6 +92,8 @@ class Ssh:
             command.append(f"-{options}")
         if self.disable_password_auth:
             command.extend(("-o", "BatchMode=yes"))
+        if self.port and self.port != DEFAULT_SSH_PORT:
+            command.extend(("-p", str(self.port)))
 
         if self.local_port_forwarding:
             command.extend(

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -66,10 +66,10 @@ class SyncedWorkspace:
         )
 
     @classmethod
-    def from_cwd(cls) -> "SyncedWorkspace":
+    def from_cwd(cls, remote_host_id: Optional[Union[str, int]] = None) -> "SyncedWorkspace":
         """Load a workspace from current working directory of user"""
         config = load_cwd_workspace_config()
-        return cls.from_config(config, Path.cwd())
+        return cls.from_config(config, Path.cwd(), remote_host_id)
 
     @classmethod
     def from_cwd_mass(cls) -> List["SyncedWorkspace"]:
@@ -83,7 +83,12 @@ class SyncedWorkspace:
         return workspaces
 
     def get_ssh(self, port_forwarding: Optional[ForwardingOptions] = None):
-        return Ssh(self.remote.host, use_gssapi_auth=self.remote.supports_gssapi, local_port_forwarding=port_forwarding)
+        return Ssh(
+            self.remote.host,
+            port=self.remote.port,
+            use_gssapi_auth=self.remote.supports_gssapi,
+            local_port_forwarding=port_forwarding,
+        )
 
     def get_ssh_for_rsync(self):
         ssh = self.get_ssh()

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -566,6 +566,7 @@ def test_medium_load_config_picks_up_vsc_ignore_files(mock_home):
     text = """
 [[hosts]]
 host = "test-host.example.com"
+port = 2022
 directory = ".remotes/workspace"
 default = true
 
@@ -607,7 +608,7 @@ pattern_two
 
     assert config == WorkspaceConfig(
         root=Path("/root/foo/bar"),
-        configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"))],
+        configurations=[RemoteConfig(host="test-host.example.com", directory=Path(".remotes/workspace"), port=2022)],
         default_configuration=0,
         ignores=SyncRules(
             pull=["*.pattern", "pattern_two"],

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 
 from remote import entrypoints
 from remote.configuration.classic import CONFIG_FILE_NAME, IGNORE_FILE_NAME, INDEX_FILE_NAME
+from remote.configuration.toml import WORKSPACE_CONFIG
 from remote.exceptions import RemoteExecutionError
 
 TEST_HOST = "test-host1.example.com"
@@ -421,6 +422,105 @@ echo test >> .file
     )
 
 
+@pytest.mark.parametrize("label, host", [("usual", "host1"), ("unusual", "host2"), ("2", "host2"), ("3", "host3")])
+@patch("remote.util.subprocess.run")
+def test_remote_labeling_works(mock_run, tmp_path, label, host):
+    mock_run.return_value = Mock(returncode=0)
+    runner = CliRunner()
+    (tmp_path / WORKSPACE_CONFIG).write_text(
+        f"""\
+[[hosts]]
+host = "host1"
+directory = "{TEST_DIR}"
+default = true
+label = "usual"
+
+[[hosts]]
+host = "host2"
+directory = "{TEST_DIR}"
+label = "unusual"
+
+[[hosts]]
+host = "host3"
+directory = "{TEST_DIR}"
+"""
+    )
+
+    with cwd(tmp_path):
+        result = runner.invoke(entrypoints.remote, ["-l", label, "echo test >> .file"])
+
+    assert result.exit_code == 0
+    assert mock_run.call_count == 3
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--delete",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
+                    "--exclude-from",
+                    ANY,
+                    f"{tmp_path}/",
+                    f"{host}:{TEST_DIR}",
+                ],
+                stdout=ANY,
+                stderr=ANY,
+            ),
+            call(
+                [
+                    "ssh",
+                    "-tKq",
+                    "-o",
+                    "BatchMode=yes",
+                    host,
+                    """if [ -f .remotes/myproject/.remoteenv ]; then
+  source .remotes/myproject/.remoteenv 2>/dev/null 1>/dev/null
+fi
+cd .remotes/myproject
+echo test >> .file
+""",
+                ],
+                stdout=ANY,
+                stdin=ANY,
+                stderr=ANY,
+            ),
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--exclude-from",
+                    ANY,
+                    f"{host}:{TEST_DIR}/",
+                    f"{tmp_path}",
+                ],
+                stdout=ANY,
+                stderr=ANY,
+            ),
+        ]
+    )
+
+
+@patch("remote.util.subprocess.run")
+def test_remote_fails_on_unknown_option(mock_run, tmp_workspace):
+    runner = CliRunner()
+
+    with cwd(tmp_workspace):
+        result = runner.invoke(entrypoints.remote, ["--unknown-opt", "echo", "test >> .file"])
+
+    assert result.exit_code == 2
+    assert "Error: no such option --unknown-opt" in result.output
+
+
 @patch("remote.util.subprocess.run")
 def test_remote_execution_fail(mock_run, tmp_workspace):
     mock_run.side_effect = [Mock(returncode=0), Mock(returncode=123), Mock(returncode=0)]
@@ -548,6 +648,17 @@ echo test
         stdin=ANY,
         stderr=ANY,
     )
+
+
+@patch("remote.util.subprocess.run")
+def test_remote_quick_fails_on_unknown_option(mock_run, tmp_workspace):
+    runner = CliRunner()
+
+    with cwd(tmp_workspace):
+        result = runner.invoke(entrypoints.remote_quick, ["--unknown-opt", "echo", "test >> .file"])
+
+    assert result.exit_code == 2
+    assert "Error: no such option --unknown-opt" in result.output
 
 
 @patch("remote.util.subprocess.run")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -140,6 +140,7 @@ def test_rsync_always_removes_temporary_files(mock_temp_file, mock_run, returnco
     "ssh, expected_cmd",
     [
         (Ssh("host"), "ssh -tKq -o BatchMode=yes"),
+        (Ssh("host", port=12345, force_tty=False), "ssh -Kq -o BatchMode=yes -p 12345"),
         (Ssh("host", force_tty=False), "ssh -Kq -o BatchMode=yes"),
         (Ssh("host", disable_password_auth=False), "ssh -tKq"),
         (Ssh("host", verbosity_level=VerbosityLevel.DEFAULT), "ssh -tK -o BatchMode=yes"),


### PR DESCRIPTION
This PR introduces two useful options:

1. Users can now set the port for remote ssh server in the config file
2. A labeled host can be picked up with `--label` command-line option

Also, I fixed a bug when unknown CLI option didn't stop the `remote` and `remote-quick` from doing the remote connection and trying to execute the command