### PR TITLE
Fix subpass pull from subdirectory

### DIFF
--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -196,8 +196,9 @@ cd {self.remote_working_dir}
                         even if it is ignored by workspace rules
         """
         if subpath is not None:
-            src = f"{self.remote.host}:{self.remote.directory}/{subpath}"
-            dst_path = self.local_root / subpath.parent
+            src = f"{self.remote.host}:{self.remote_working_dir}/{subpath}"
+            local_subpath = self.remote_working_dir.relative_to(self.remote.directory) / subpath
+            dst_path = self.local_root / local_subpath.parent
             dst_path.mkdir(parents=True, exist_ok=True)
             dst = f"{dst_path}/"
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -148,6 +148,28 @@ def test_pull_with_subdir(mock_run, workspace):
             "-e",
             "ssh -Kq -o BatchMode=yes",
             "--force",
+            f"{workspace.remote.host}:{workspace.remote.directory}/foo/bar/some-path",
+            f"{workspace.local_root}/foo/bar/",
+        ],
+        stderr=ANY,
+        stdout=ANY,
+    )
+
+
+@patch("remote.util.subprocess.run")
+def test_pull_with_subdir_exec_from_root(mock_run, workspace):
+    workspace.remote_working_dir = workspace.remote.directory
+    mock_run.return_value = MagicMock(returncode=0)
+
+    workspace.pull(subpath=Path("some-path"))
+    mock_run.assert_called_once_with(
+        [
+            "rsync",
+            "-arlpmchz",
+            "--copy-unsafe-links",
+            "-e",
+            "ssh -Kq -o BatchMode=yes",
+            "--force",
             f"{workspace.remote.host}:{workspace.remote.directory}/some-path",
             f"{workspace.local_root}/",
         ],


### PR DESCRIPTION
There is an issue that happens when a user is trying to execute `remote-pull path` from the workspace's subdirectory. For example if user does following:

```
remote-init myhost
cd subproject
remote ./build
remote-pull logs
```

They would expect `remote-pull` to pull in `<workspace_root>/subproject/logs`, but it will actually try to pull `<workspace_root>/logs`.

This RB fixes it.