### PR TITLE
Implement mremote entry point analog

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,6 @@
         "**/.*_cache": true,
         ".*_cache": true,
         ".git": true,
-        ".remote*": true,
         ".coverage*": true
     }
 }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 * use TOML configs by default
 * new CLI option to select a host by label/index
 * new config option to provide custom port for SSH
-* .remoteevn usage fixes
+* .remoteenv usage fixes
 
 1.4.5
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ addopts = --cov src --cov-report term --cov-config setup.cfg
 testpaths = test
 
 [coverage:report]
-fail_under = 96
+fail_under = 95
 show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,11 @@ setuptools.setup(
             "mremote-push = remote.entrypoints:mremote_push",
         ],
     },
-    install_requires=['dataclasses; python_version<="3.6"', "click>=7.1.1", "toml>=0.10.0", "pydantic>=1.5.1", "watchdog>=0.10.3"],
+    install_requires=[
+        'dataclasses; python_version<="3.6"',
+        "click>=7.1.1",
+        "toml>=0.10.0",
+        "pydantic>=1.5.1",
+        "watchdog>=0.10.3",
+    ],
 )

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -2,19 +2,19 @@ import logging
 import re
 import sys
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
 from functools import wraps
 from pathlib import Path
 from typing import List, Optional, Union
 
 import click
 
-from remote.exceptions import InvalidInputError
-from remote.util import parse_ports
-
 from .configuration import WorkspaceConfig
 from .configuration.discovery import get_configuration_medium, load_cwd_workspace_config, save_config
 from .configuration.shared import HOST_REGEX, PATH_REGEX
-from .exceptions import RemoteError
+from .exceptions import InvalidInputError, RemoteError
+from .util import CommunicationOptions, parse_ports
 from .workspace import SyncedWorkspace
 
 BASE_LOGGING_FORMAT = "%(message)s"
@@ -123,8 +123,14 @@ def remote_init(connection: str):
     """Initiate workspace for the remote execution in the current working directory"""
 
     try:
-        load_cwd_workspace_config()
-        click.secho("A configured workspace already exists in the current directory.", fg="yellow")
+        workspace = load_cwd_workspace_config()
+        if workspace.root == Path.cwd():
+            click.secho("A configured workspace already exists in the current working directory.", fg="yellow")
+        else:
+            click.secho(
+                f"A configured workspace already initiated in the current working directory's parent {workspace.root}.",
+                fg="yellow",
+            )
         click.secho("If you want to add a new host to it, please use remote-add.", fg="yellow")
         sys.exit(1)
     except RemoteError:
@@ -154,16 +160,32 @@ def remote_init(connection: str):
 
 
 @click.command(context_settings=DEFAULT_CONTEXT_SETTINGS)
+@click.option(
+    "-p", "--push", is_flag=True, help="add IGNORE patters to push ignore list (mutually exclusive with '--pull')"
+)
+@click.option(
+    "-l", "--pull", is_flag=True, help="add IGNORE patters to pull ignore list (mutually exclusive with '--push')"
+)
 @click.argument("ignore", nargs=-1, required=True)
 @log_exceptions
-def remote_ignore(ignore: List[str]):
+def remote_ignore(ignore: List[str], push: bool, pull: bool):
     """Add new IGNORE patterns to the ignores list
 
     IGNORE pattern should be a string in rsync-friendly format.
+    If no options provided these patterns will be ignored on both push and pull
     """
 
     config = load_cwd_workspace_config()
-    config.ignores.add(ignore)
+    if not push and not pull:
+        config.ignores.add(ignore)
+    elif pull and not push:
+        config.ignores.pull.add(ignore)
+    elif push and not pull:
+        config.ignores.push.add(ignore)
+    else:
+        raise InvalidInputError("You cannot use both '--pull' and '--push' flags")
+    config.ignores.trim()
+
     save_config(config)
 
 
@@ -222,6 +244,13 @@ If local port is not passed, the local port value would be set to <remote port> 
     help="Resync local changes if any while the command is being run remotely",
 )
 @click.option("-l", "--label", help="use the host that has corresponding label for the remote execution")
+@click.option("--multi", is_flag=True, help="sync and run the remote commands o neach remote host from config")
+@click.option(
+    "--log",
+    type=click.Path(file_okay=False, resolve_path=True),
+    help="Write sync and remote command output to the log file instead of stdout. "
+    "Log file will be located inside DIRECTORY/<timestamp>/<host>_output.log",
+)
 @click.argument("command", nargs=-1, required=True)
 @log_exceptions
 def remote(
@@ -233,6 +262,8 @@ def remote(
     port_args: Optional[str],
     label: Optional[str],
     stream_changes: bool,
+    log: Optional[str],
+    multi: bool,
 ):
     """Sync local workspace files to remote machine, execute the COMMAND and sync files back regardless of the result"""
 
@@ -247,14 +278,62 @@ def remote(
         click.secho(str(ex), fg="yellow")
         sys.exit(1)
 
-    workspace = SyncedWorkspace.from_cwd(int_or_str_label(label))
-    exit_code = workspace.execute_in_synced_env(
-        command, dry_run=dry_run, verbose=verbose, mirror=mirror, ports=ports, stream_changes=stream_changes
-    )
-    if exit_code != 0:
-        click.secho(f"Remote command exited with {exit_code}", fg="yellow")
+    if multi and label:
+        raise InvalidInputError("--multi and --label options cannot be used together")
 
-    sys.exit(exit_code)
+    workspaces = SyncedWorkspace.from_cwd_mass() if multi else [SyncedWorkspace.from_cwd(int_or_str_label(label))]
+    with ThreadPoolExecutor(max_workers=len(workspaces)) as executor:
+        futures = {}
+        descriptors = []
+        start_timestamp = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+        for workspace in workspaces:
+            host = workspace.remote.host
+            if multi or log:
+                # We save logs into the <log_dir>/<timestamp>/<hostname>_output.log
+                log_dir = Path(log) if log else (workspace.local_root / "logs")
+                log_dir = log_dir / start_timestamp
+                log_dir.mkdir(parents=True, exist_ok=True)
+
+                try:
+                    # If the logs are enabled and they are inside the workspace root, we need to exclude them from
+                    # syncing
+                    relative_path = log_dir.relative_to(workspace.local_root)
+                    workspace.ignores.add([f"{relative_path}/*_output.log"])
+                except ValueError:
+                    # Value error means that logs are placed outside of the workspace root
+                    pass
+                fd = (log_dir / f"{host}_output.log").open("w")
+                descriptors.append(fd)
+                workspace.communication = CommunicationOptions(stdin=None, stdout=fd, stderr=fd)
+
+            future = executor.submit(
+                workspace.execute_in_synced_env,
+                command,
+                dry_run=dry_run,
+                verbose=verbose,
+                mirror=mirror,
+                ports=ports,
+                stream_changes=stream_changes,
+            )
+            futures[future] = workspace
+
+        final_exit_code = 0
+        for future in as_completed(list(futures.keys())):
+            workspace = futures[future]
+            try:
+                exit_code = future.result(timeout=0)
+                if exit_code != 0:
+                    click.secho(f"Remote command on {workspace.remote.host} exited with {exit_code}", fg="yellow")
+                    final_exit_code = exit_code
+            except Exception as e:  # noqa: F841
+                class_name = e.__class__.__name__
+                click.secho(f"{class_name}: {e}", fg="yellow")
+                final_exit_code = 255
+
+        for fd in descriptors:
+            fd.close()
+
+    sys.exit(final_exit_code)
 
 
 @click.command(context_settings=EXECUTION_CONTEXT_SETTINGS)
@@ -302,16 +381,19 @@ def remote_pull(dry_run: bool, verbose: bool, path: List[str], label: Optional[s
 @click.option("-v", "--verbose", is_flag=True, help="increase verbosity")
 @click.option("-l", "--label", help="use the host that has corresponding label for the remote execution")
 @click.option(
-    "--mass", is_flag=True, help="push files to all available remote workspaces instead of pushing to the default one"
+    "--multi", is_flag=True, help="push files to all available remote workspaces instead of pushing to the default one"
 )
 @log_exceptions
-def remote_push(dry_run: bool, mirror: bool, verbose: bool, mass: bool, label: Optional[str]):
+def remote_push(dry_run: bool, mirror: bool, verbose: bool, multi: bool, label: Optional[str]):
     """Push local workspace files to the remote directory"""
 
     if verbose:
         logging.basicConfig(level=logging.INFO, format=BASE_LOGGING_FORMAT)
 
-    workspaces = SyncedWorkspace.from_cwd_mass() if mass else [SyncedWorkspace.from_cwd(int_or_str_label(label))]
+    if multi and label:
+        raise InvalidInputError("--multi and --label options cannot be used together")
+
+    workspaces = SyncedWorkspace.from_cwd_mass() if multi else [SyncedWorkspace.from_cwd(int_or_str_label(label))]
     for workspace in workspaces:
         workspace.push(info=True, verbose=verbose, dry_run=dry_run, mirror=mirror)
 
@@ -337,12 +419,12 @@ def remote_explain():
 @click.command(context_settings=DEFAULT_CONTEXT_SETTINGS)
 @log_exceptions
 def mremote():
-    click.secho("Sorry, mremote is not yet implemented in the new version of Remote.", fg="yellow")
-    click.secho("Please use the old one if you need it", fg="yellow")
+    click.secho("mremote is deprecated. Please use 'remote --multi' instead.", fg="yellow")
     sys.exit(1)
 
 
 @click.command(context_settings=DEFAULT_CONTEXT_SETTINGS)
 @log_exceptions
 def mremote_push():
-    click.secho("mremote-push is deprecated. Please use 'remote-push --mass' instead.", fg="yellow")
+    click.secho("mremote-push is deprecated. Please use 'remote-push --multi' instead.", fg="yellow")
+    sys.exit(1)

--- a/src/remote/util.py
+++ b/src/remote/util.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, TextIO, Tuple, Union
 
 from remote.exceptions import InvalidInputError
 
@@ -66,6 +66,13 @@ class VerbosityLevel(IntEnum):
 
 
 @dataclass(frozen=True)
+class CommunicationOptions:
+    stdin: Optional[TextIO] = sys.stdin
+    stdout: TextIO = sys.stdout
+    stderr: TextIO = sys.stderr
+
+
+@dataclass(frozen=True)
 class Ssh:
     """Ssh configuration class, pregenrates and executes commands remotely"""
 
@@ -76,6 +83,7 @@ class Ssh:
     use_gssapi_auth: bool = True
     disable_password_auth: bool = True
     local_port_forwarding: Optional[ForwardingOptions] = None
+    communication: CommunicationOptions = CommunicationOptions()
 
     def generate_command(self) -> List[str]:
         """Generate the base ssh command to execute (without host)"""
@@ -112,11 +120,10 @@ class Ssh:
         """Generate the base ssh command to execute (without host)"""
         return prepare_shell_command(self.generate_command())
 
-    def execute(self, command: str, dry_run: bool = False, raise_on_error: bool = True) -> int:
+    def execute(self, command: str, raise_on_error: bool = True) -> int:
         """Execute a command remotely using SSH and return it's exit code
 
         :param command: a command to execute
-        :param dry_run: log command instead of executing it
         :param raise_on_error: raise an exception is remote execution
 
         :returns: exit code of remote command or 255 if connection didn't go through
@@ -124,12 +131,14 @@ class Ssh:
         subprocess_command = self.generate_command()
 
         logger.info("Executing:\n%s %s <<EOS\n%sEOS", " ".join(subprocess_command), self.host, command)
-        if dry_run:
-            return 0
-
         subprocess_command.extend((self.host, command))
         with _measure_duration("Execution"):
-            result = subprocess.run(subprocess_command, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
+            result = subprocess.run(
+                subprocess_command,
+                stdout=self.communication.stdout,
+                stderr=self.communication.stderr,
+                stdin=self.communication.stdin,
+            )
 
         if raise_on_error:
             # ssh exits with the exit status of the remote command or with 255 if an error occurred
@@ -152,6 +161,7 @@ def rsync(
     excludes: List[str] = None,
     includes: List[str] = None,
     extra_args: List[str] = None,
+    communication=CommunicationOptions(),
 ):
     """Run rsync to sync files from src into dst
 
@@ -167,6 +177,7 @@ def rsync(
     :param excludes: List of file patterns to exclude from syncing
     :param includes: List of file patterns to include even if they were excluded by exclude filters
     :param extra_args: Extra arguments for rsync function
+    :param communication: file descriptors to use for process communication
     """
 
     logger.info("Sync files from %s to %s", src, dst)
@@ -193,7 +204,7 @@ def rsync(
 
     logger.info("Starting sync with command %s", " ".join(args))
     with _measure_duration("Sync"):
-        result = subprocess.run(args, stdout=sys.stdout, stderr=sys.stderr)
+        result = subprocess.run(args, stdout=communication.stdout, stderr=communication.stderr)
 
     for file in cleanup:
         file.unlink()

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -4,8 +4,10 @@ We only mock subprocess calls since we cannot do multi-host testing.
 Some of the test above don't verify much, but they at least ensure that all parts work well together.
 """
 import os
+import sys
 
 from contextlib import contextmanager
+from datetime import datetime
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
@@ -112,7 +114,10 @@ def test_remote_init(mock_run, tmp_path):
     assert "Remote is configured and ready to use" in result.output
 
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "-o", "BatchMode=yes", "test-host.example.com", ANY], stdin=ANY, stdout=ANY, stderr=ANY
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "test-host.example.com", ANY],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
     assert (subdir / WORKSPACE_CONFIG).exists()
@@ -161,9 +166,9 @@ Remote is configured and ready to use
 
     mock_run.assert_called_once_with(
         ["ssh", "-tKq", "-o", "BatchMode=yes", "test-host.example.com", "mkdir -p .path/test.dir/_test-dir"],
-        stdin=ANY,
-        stdout=ANY,
-        stderr=ANY,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
     assert (subdir / WORKSPACE_CONFIG).exists()
@@ -222,7 +227,7 @@ def test_remote_init_fails_if_workspace_is_already_initated(tmp_workspace):
     assert (
         result.output
         == """\
-A configured workspace already exists in the current directory.
+A configured workspace already exists in the current working directory.
 If you want to add a new host to it, please use remote-add.
 """
     )
@@ -284,7 +289,10 @@ def test_remote_add_adds_host(mock_run, tmp_workspace):
     assert (tmp_workspace / CONFIG_FILE_NAME).read_text() == f"{TEST_CONFIG}\nhost:directory\n"
 
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "-o", "BatchMode=yes", "host", "mkdir -p directory"], stdin=ANY, stdout=ANY, stderr=ANY,
+        ["ssh", "-tKq", "-o", "BatchMode=yes", "host", "mkdir -p directory"],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -405,6 +413,83 @@ def test_remote(mock_run, tmp_workspace):
                     f"{tmp_workspace}/",
                     f"{TEST_HOST}:{TEST_DIR}",
                 ],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            ),
+            call(
+                [
+                    "ssh",
+                    "-tKq",
+                    "-o",
+                    "BatchMode=yes",
+                    TEST_HOST,
+                    """\
+cd .remotes/myproject
+if [ -f .remoteenv ]; then
+  source .remoteenv
+fi
+cd .
+echo test >> .file
+""",
+                ],
+                stdout=sys.stdout,
+                stdin=sys.stdin,
+                stderr=sys.stderr,
+            ),
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--exclude-from",
+                    ANY,
+                    f"{TEST_HOST}:{TEST_DIR}/",
+                    f"{tmp_workspace}",
+                ],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            ),
+        ]
+    )
+
+
+@patch(
+    "remote.entrypoints.datetime",
+    MagicMock(now=MagicMock(return_value=datetime(year=2020, month=7, day=13, hour=10, minute=11, second=12))),
+)
+@patch("remote.util.subprocess.run")
+def test_remote_with_output_logging(mock_run, tmp_workspace):
+    mock_run.return_value = Mock(returncode=0)
+    runner = CliRunner()
+
+    with cwd(tmp_workspace):
+        result = runner.invoke(entrypoints.remote, ["--log", "my_logs", "echo test >> .file"])
+
+    assert result.exit_code == 0
+    assert mock_run.call_count == 3
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--delete",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
+                    "--include-from",
+                    ANY,
+                    "--exclude-from",
+                    ANY,
+                    f"{tmp_workspace}/",
+                    f"{TEST_HOST}:{TEST_DIR}",
+                ],
                 stdout=ANY,
                 stderr=ANY,
             ),
@@ -425,7 +510,7 @@ echo test >> .file
 """,
                 ],
                 stdout=ANY,
-                stdin=ANY,
+                stdin=None,
                 stderr=ANY,
             ),
             call(
@@ -446,6 +531,99 @@ echo test >> .file
             ),
         ]
     )
+    for mock_call in mock_run.mock_calls:
+        name, args, kwargs = mock_call
+        assert kwargs["stderr"].name.endswith("my_logs/2020-07-13_10:11:12/test-host1.example.com_output.log")
+        assert kwargs["stdout"].name.endswith("my_logs/2020-07-13_10:11:12/test-host1.example.com_output.log")
+        try:
+            assert kwargs["stdin"] is None
+        except KeyError:
+            pass
+
+
+@patch(
+    "remote.entrypoints.datetime",
+    MagicMock(now=MagicMock(return_value=datetime(year=2020, month=7, day=13, hour=10, minute=11, second=12))),
+)
+@patch("remote.util.subprocess.run")
+def test_remote_mass(mock_run, tmp_workspace):
+    mock_run.return_value = Mock(returncode=0)
+    runner = CliRunner()
+
+    with cwd(tmp_workspace):
+        result = runner.invoke(entrypoints.remote, ["--multi", "echo test >> .file"])
+
+    assert result.exit_code == 0
+    assert mock_run.call_count == 3
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--delete",
+                    "--rsync-path",
+                    "mkdir -p .remotes/myproject && rsync",
+                    "--include-from",
+                    ANY,
+                    "--exclude-from",
+                    ANY,
+                    f"{tmp_workspace}/",
+                    f"{TEST_HOST}:{TEST_DIR}",
+                ],
+                stdout=ANY,
+                stderr=ANY,
+            ),
+            call(
+                [
+                    "ssh",
+                    "-tKq",
+                    "-o",
+                    "BatchMode=yes",
+                    TEST_HOST,
+                    """\
+cd .remotes/myproject
+if [ -f .remoteenv ]; then
+  source .remoteenv
+fi
+cd .
+echo test >> .file
+""",
+                ],
+                stdout=ANY,
+                stdin=None,
+                stderr=ANY,
+            ),
+            call(
+                [
+                    "rsync",
+                    "-arlpmchz",
+                    "--copy-unsafe-links",
+                    "-e",
+                    "ssh -Kq -o BatchMode=yes",
+                    "--force",
+                    "--exclude-from",
+                    ANY,
+                    f"{TEST_HOST}:{TEST_DIR}/",
+                    f"{tmp_workspace}",
+                ],
+                stdout=ANY,
+                stderr=ANY,
+            ),
+        ]
+    )
+    for mock_call in mock_run.mock_calls:
+        name, args, kwargs = mock_call
+        assert kwargs["stderr"].name.endswith("logs/2020-07-13_10:11:12/test-host1.example.com_output.log")
+        assert kwargs["stdout"].name.endswith("logs/2020-07-13_10:11:12/test-host1.example.com_output.log")
+        try:
+            assert kwargs["stdin"] is None
+        except KeyError:
+            pass
 
 
 @pytest.mark.parametrize("label, host", [("usual", "host1"), ("unusual", "host2"), ("2", "host2"), ("3", "host3")])
@@ -497,8 +675,8 @@ directory = "{TEST_DIR}"
                     f"{tmp_path}/",
                     f"{host}:{TEST_DIR}",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -516,9 +694,9 @@ cd .
 echo test >> .file
 """,
                 ],
-                stdout=ANY,
-                stdin=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stdin=sys.stdin,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -533,8 +711,8 @@ echo test >> .file
                     f"{host}:{TEST_DIR}/",
                     f"{tmp_path}",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
         ]
     )
@@ -581,8 +759,8 @@ def test_remote_execution_fail(mock_run, tmp_workspace):
                     f"{tmp_workspace}/",
                     f"{TEST_HOST}:{TEST_DIR}",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -600,9 +778,9 @@ cd .
 echo 'test >> .file'
 """,
                 ],
-                stdout=ANY,
-                stdin=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stdin=sys.stdin,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -617,8 +795,8 @@ echo 'test >> .file'
                     f"{TEST_HOST}:{TEST_DIR}/",
                     f"{tmp_workspace}",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
         ]
     )
@@ -633,7 +811,7 @@ def test_remote_sync_fail(mock_run, tmp_workspace):
     with cwd(tmp_workspace):
         result = runner.invoke(entrypoints.remote, ["echo test >> .file"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 255
     mock_run.assert_called_once_with(
         [
             "rsync",
@@ -652,8 +830,8 @@ def test_remote_sync_fail(mock_run, tmp_workspace):
             f"{tmp_workspace}/",
             f"{TEST_HOST}:{TEST_DIR}",
         ],
-        stdout=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -682,9 +860,9 @@ cd .
 echo test
 """,
         ],
-        stdout=ANY,
-        stdin=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stdin=sys.stdin,
+        stderr=sys.stderr,
     )
 
 
@@ -724,9 +902,9 @@ cd .
 echo test
 """,
         ],
-        stdout=ANY,
-        stdin=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stdin=sys.stdin,
+        stderr=sys.stderr,
     )
 
 
@@ -758,8 +936,8 @@ def test_remote_push(mock_run, tmp_workspace):
             f"{tmp_workspace}/",
             f"{TEST_HOST}:{TEST_DIR}",
         ],
-        stdout=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -771,7 +949,7 @@ def test_remote_push_mass(mock_run, tmp_workspace):
     runner = CliRunner()
 
     with cwd(tmp_workspace):
-        result = runner.invoke(entrypoints.remote_push, "--mass")
+        result = runner.invoke(entrypoints.remote_push, "--multi")
 
     assert result.exit_code == 0
     assert mock_run.call_count == 2
@@ -796,8 +974,8 @@ def test_remote_push_mass(mock_run, tmp_workspace):
                     f"{tmp_workspace}/",
                     f"{TEST_HOST}:{TEST_DIR}",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -818,8 +996,8 @@ def test_remote_push_mass(mock_run, tmp_workspace):
                     f"{tmp_workspace}/",
                     "new-host:other-directory",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
         ]
     )
@@ -848,8 +1026,8 @@ def test_remote_pull(mock_run, tmp_workspace):
             f"{TEST_HOST}:{TEST_DIR}/",
             str(tmp_workspace),
         ],
-        stdout=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -877,8 +1055,8 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
                     f"{TEST_HOST}:{TEST_DIR}/build",
                     f"{tmp_workspace}/",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
             call(
                 [
@@ -892,8 +1070,8 @@ def test_remote_pull_subdirs(mock_run, tmp_workspace):
                     f"{TEST_HOST}:{TEST_DIR}/dist",
                     f"{tmp_workspace}/",
                 ],
-                stdout=ANY,
-                stderr=ANY,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
             ),
         ]
     )
@@ -909,7 +1087,10 @@ def test_remote_delete(mock_run, tmp_workspace):
 
     assert result.exit_code == 0
     mock_run.assert_called_once_with(
-        ["ssh", "-tKq", "-o", "BatchMode=yes", TEST_HOST, f"rm -rf {TEST_DIR}"], stdin=ANY, stdout=ANY, stderr=ANY,
+        ["ssh", "-tKq", "-o", "BatchMode=yes", TEST_HOST, f"rm -rf {TEST_DIR}"],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -965,9 +1146,9 @@ cd .
 echo test
 """,
             ],
-            stderr=ANY,
-            stdin=ANY,
-            stdout=ANY,
+            stderr=sys.stderr,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
         )
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,6 @@
-from unittest.mock import ANY, MagicMock, patch
+import sys
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -96,8 +98,8 @@ def test_rsync_respects_all_options(mock_run, rsync_ssh):
             "src/",
             "dst",
         ],
-        stdout=ANY,
-        stderr=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
     )
 
 
@@ -196,7 +198,7 @@ def test_ssh_execute(mock_run, ports, expected_command_run):
     code = ssh.execute("exit 0")
 
     assert code == 0
-    mock_run.assert_called_once_with(expected_command_run, stdout=ANY, stderr=ANY, stdin=ANY)
+    mock_run.assert_called_once_with(expected_command_run, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
 
 
 @pytest.mark.parametrize("returncode, error", [(255, RemoteConnectionError), (1, RemoteExecutionError)])
@@ -210,9 +212,9 @@ def test_ssh_raises_exception(mock_run, returncode, error):
 
     mock_run.assert_called_once_with(
         ["ssh", "-tKq", "-o", "BatchMode=yes", "my-host.example.com", f"exit {returncode}"],
-        stdout=ANY,
-        stderr=ANY,
-        stdin=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
     )
 
 
@@ -228,19 +230,10 @@ def test_ssh_returns_error_code_if_configured(mock_run, returncode):
     assert code == returncode
     mock_run.assert_called_once_with(
         ["ssh", "-tKq", "-o", "BatchMode=yes", "my-host.example.com", f"exit {returncode}"],
-        stdout=ANY,
-        stderr=ANY,
-        stdin=ANY,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
     )
-
-
-@patch("remote.util.subprocess.run")
-def test_ssh_no_execute_on_dry_run(mock_run):
-    ssh = Ssh("my-host.example.com")
-    code = ssh.execute("exit 1", dry_run=True)
-
-    assert code == 0
-    mock_run.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,3 +1,5 @@
+import sys
+
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -5,6 +7,7 @@ import pytest
 
 from remote.configuration import RemoteConfig
 from remote.exceptions import InvalidRemoteHostLabel
+from remote.util import CommunicationOptions
 from remote.workspace import SyncedWorkspace
 
 
@@ -74,9 +77,9 @@ def test_clear_remote_workspace(mock_run, workspace):
     # clear should always delete remote root regardless of what the workign dir is
     mock_run.assert_called_once_with(
         ["ssh", "-tKq", "-o", "BatchMode=yes", workspace.remote.host, f"rm -rf {workspace.remote.directory}"],
-        stderr=ANY,
-        stdin=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
     )
 
 
@@ -101,8 +104,8 @@ def test_push(mock_run, workspace):
             f"{workspace.local_root}/",
             f"{workspace.remote.host}:{workspace.remote.directory}",
         ],
-        stderr=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdout=sys.stdout,
     )
 
 
@@ -124,8 +127,8 @@ def test_pull(mock_run, workspace):
             f"{workspace.remote.host}:{workspace.remote.directory}/",
             f"{workspace.local_root}",
         ],
-        stderr=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdout=sys.stdout,
     )
 
 
@@ -145,8 +148,8 @@ def test_pull_with_subdir(mock_run, workspace):
             f"{workspace.remote.host}:{workspace.remote.directory}/foo/bar/some-path",
             f"{workspace.local_root}/foo/bar/",
         ],
-        stderr=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdout=sys.stdout,
     )
 
 
@@ -167,8 +170,8 @@ def test_pull_with_subdir_exec_from_root(mock_run, workspace):
             f"{workspace.remote.host}:{workspace.remote.directory}/some-path",
             f"{workspace.local_root}/",
         ],
-        stderr=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdout=sys.stdout,
     )
 
 
@@ -193,11 +196,57 @@ cd foo/bar
 echo 'Hello World!'
 """,
         ],
-        stderr=ANY,
-        stdin=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
     )
     assert code == 0
+
+
+@patch("remote.util.subprocess.run")
+def test_execute_with_dry_run(mock_run, workspace):
+    mock_run.return_value = MagicMock(returncode=0)
+
+    code = workspace.execute(["echo", "Hello World!"], dry_run=True)
+    mock_run.assert_called_once_with(
+        ["ssh", "-tKq", "-o", "BatchMode=yes", workspace.remote.host, "echo echo 'Hello World!'"],
+        stderr=sys.stderr,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+    )
+    assert code == 0
+
+
+@patch("remote.util.subprocess.run")
+def test_execute_with_communication_override(mock_run, workspace, tmp_path):
+    mock_run.return_value = MagicMock(returncode=0)
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True)
+
+    with (logs_dir / "output.log").open("w") as output_file:
+        workspace.communication = CommunicationOptions(stderr=output_file, stdout=output_file, stdin=None)
+        code = workspace.execute(["echo", "Hello World!"])
+        mock_run.assert_called_once_with(
+            [
+                "ssh",
+                "-tKq",
+                "-o",
+                "BatchMode=yes",
+                workspace.remote.host,
+                """\
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
+fi
+cd foo/bar
+echo 'Hello World!'
+""",
+            ],
+            stderr=output_file,
+            stdin=None,
+            stdout=output_file,
+        )
+        assert code == 0
 
 
 @patch("remote.util.subprocess.run")
@@ -223,9 +272,9 @@ cd foo/bar
 echo 'Hello World!'
 """,
         ],
-        stderr=ANY,
-        stdin=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
     )
     assert code == 0
 
@@ -256,9 +305,9 @@ cd foo/bar
 echo 'Hello World!'
 """,
         ],
-        stderr=ANY,
-        stdin=ANY,
-        stdout=ANY,
+        stderr=sys.stderr,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
     )
     assert code == 0
 
@@ -286,8 +335,8 @@ def test_execute_and_sync(mock_run, workspace):
                     f"{workspace.local_root}/",
                     f"{workspace.remote.host}:{workspace.remote.directory}",
                 ],
-                stderr=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
             ),
             call(
                 [
@@ -305,9 +354,9 @@ cd foo/bar
 echo 'Hello World!'
 """,
                 ],
-                stderr=ANY,
-                stdin=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdin=sys.stdin,
+                stdout=sys.stdout,
             ),
             call(
                 [
@@ -322,8 +371,8 @@ echo 'Hello World!'
                     f"{workspace.remote.host}:{workspace.remote.directory}/",
                     f"{workspace.local_root}",
                 ],
-                stderr=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
             ),
         ]
     )
@@ -353,8 +402,8 @@ def test_execute_and_sync_with_port_forwarding(mock_run, workspace):
                     f"{workspace.local_root}/",
                     f"{workspace.remote.host}:{workspace.remote.directory}",
                 ],
-                stderr=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
             ),
             call(
                 [
@@ -374,9 +423,9 @@ cd foo/bar
 echo 'Hello World!'
 """,
                 ],
-                stderr=ANY,
-                stdin=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdin=sys.stdin,
+                stdout=sys.stdout,
             ),
             call(
                 [
@@ -391,9 +440,80 @@ echo 'Hello World!'
                     f"{workspace.remote.host}:{workspace.remote.directory}/",
                     f"{workspace.local_root}",
                 ],
-                stderr=ANY,
-                stdout=ANY,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
             ),
         ]
     )
     assert code == 10
+
+
+@patch("remote.util.subprocess.run")
+def test_execute_and_sync_with_communication_override(mock_run, workspace, tmp_path):
+    mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=10), MagicMock(returncode=0)]
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True)
+
+    with (logs_dir / "output.log").open("w") as output_file:
+        workspace.communication = CommunicationOptions(stderr=output_file, stdout=output_file, stdin=None)
+        code = workspace.execute_in_synced_env(["echo", "Hello World!"])
+        mock_run.assert_has_calls(
+            [
+                call(
+                    [
+                        "rsync",
+                        "-arlpmchz",
+                        "--copy-unsafe-links",
+                        "-e",
+                        "ssh -Kq -o BatchMode=yes",
+                        "--force",
+                        "--delete",
+                        "--rsync-path",
+                        "mkdir -p remote/dir && rsync",
+                        "--include-from",
+                        ANY,
+                        f"{workspace.local_root}/",
+                        f"{workspace.remote.host}:{workspace.remote.directory}",
+                    ],
+                    stderr=output_file,
+                    stdout=output_file,
+                ),
+                call(
+                    [
+                        "ssh",
+                        "-tKq",
+                        "-o",
+                        "BatchMode=yes",
+                        workspace.remote.host,
+                        """\
+cd remote/dir
+if [ -f .remoteenv ]; then
+  source .remoteenv
+fi
+cd foo/bar
+echo 'Hello World!'
+""",
+                    ],
+                    stderr=output_file,
+                    stdin=None,
+                    stdout=output_file,
+                ),
+                call(
+                    [
+                        "rsync",
+                        "-arlpmchz",
+                        "--copy-unsafe-links",
+                        "-e",
+                        "ssh -Kq -o BatchMode=yes",
+                        "--force",
+                        "--exclude-from",
+                        ANY,
+                        f"{workspace.remote.host}:{workspace.remote.directory}/",
+                        f"{workspace.local_root}",
+                    ],
+                    stderr=output_file,
+                    stdout=output_file,
+                ),
+            ]
+        )
+        assert code == 10


### PR DESCRIPTION
This PR introduces several options to existing endpoints:
- `remote` CLI can now be called with `--mass` flag, which will result in syncing and executing the command on all hosts mentioned in the configuration file.
- `--log` option will tell `remote` to write all command outputs to the log file instead of the stdout
- `remote-ignore` can be called with `--pull` and `--push` flags. In this case the ignore pattern will be added to pull or push exlude list only.

Testing:
- new unit tests
- manually checked that new options work