### PR TITLE
Feature: Enable --stream-changes while executing long running commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,42 +25,6 @@ jobs:
           with:
             name: remote-sh
             path: remote-sh.tgz
-
-    pyoxidizer-tgz:
-      name: Build pyoxidizer implementation
-      runs-on: macos-latest
-      steps:
-        - name: Check out code
-          uses: actions/checkout@v2
-        - name: Set up cargo
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
-        - name: Set up Python
-          uses: actions/setup-python@v1
-          with:
-            python-version: 3.8
-        - name: Install pyoxidizer
-          run: cargo install pyoxidizer
-        - name: Build executable and tgz
-          run: |
-            mkdir -p build/remote/bin
-            pyoxidizer build --release
-            cp build/*/release/exe/remote-exec build/remote/bin
-            pip install -e .
-            python scripts/setup-entrypoints.py build/remote/bin
-            cd build
-            tar -cvzf ../remote-pyoxidizer-macos-latest.tgz remote
-        - name: Test binary is ok
-          run: build/remote/bin/remote -h
-        - name: Upload release artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: remote-pyoxidizer-macos-latest
-            path: remote-pyoxidizer-macos-latest.tgz
-
     shiv-tgz:
       name: Build shiv implementation
       runs-on: ubuntu-latest
@@ -94,7 +58,6 @@ jobs:
       runs-on: ubuntu-latest
       needs:
         - bash-tgz
-        - pyoxidizer-tgz
         - shiv-tgz
       if: github.event_name == 'push'
       steps:
@@ -107,10 +70,6 @@ jobs:
           uses: actions/download-artifact@v2
           with:
             name: remote-sh
-        - name: Fetch pyoxidizer macos artifact
-          uses: actions/download-artifact@v2
-          with:
-            name: remote-pyoxidizer-macos-latest
         - name: Fetch shiv multiplatform artifact
           uses: actions/download-artifact@v2
           with:
@@ -135,15 +94,6 @@ jobs:
             upload_url: ${{ steps.create_release.outputs.upload_url }}
             asset_path: ./remote-sh.tgz
             asset_name: remote-${{ steps.release_info.outputs.version }}-sh.tgz
-            asset_content_type: applictaion/gzip
-        - name: Upload pyoxidizer macos artifact
-          uses: actions/upload-release-asset@v1
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_path: ./remote-pyoxidizer-macos-latest.tgz
-            asset_name: remote-${{ steps.release_info.outputs.version }}-macos.tgz
             asset_content_type: applictaion/gzip
         - name: Upload shiv artifact
           uses: actions/upload-release-asset@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ addopts = --cov src --cov-report term --cov-config setup.cfg
 testpaths = test
 
 [coverage:report]
-fail_under = 95
+fail_under = 96
 show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,5 @@ setuptools.setup(
             "mremote-push = remote.entrypoints:mremote_push",
         ],
     },
-    install_requires=['dataclasses; python_version<="3.6"', "click>=7.1.1", "toml>=0.10.0", "pydantic>=1.5.1"],
+    install_requires=['dataclasses; python_version<="3.6"', "click>=7.1.1", "toml>=0.10.0", "pydantic>=1.5.1", "watchdog>=0.10.3"],
 )

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -219,8 +219,7 @@ If local port is not passed, the local port value would be set to <remote port> 
     "--stream-changes",
     default=False,
     is_flag=True,
-    help="Continuously sync files from local to remote \
-     while executing the command",
+    help="Resync local changes if any while the command is being run remotely",
 )
 @click.option("-l", "--label", help="use the host that has corresponding label for the remote execution")
 @click.argument("command", nargs=-1, required=True)

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -215,8 +215,8 @@ def remote_set(index: int):
 If local port is not passed, the local port value would be set to <remote port> value by default",
 )
 @click.option(
-    "-h",
-    "--hot-reload",
+    "-s",
+    "--stream-changes",
     default=False,
     is_flag=True,
     help="Continuously sync files from local to remote \
@@ -233,7 +233,7 @@ def remote(
     e: bool,
     port_args: Optional[str],
     label: Optional[str],
-    hot_reload: bool,
+    stream_changes: bool,
 ):
     """Sync local workspace files to remote machine, execute the COMMAND and sync files back regardless of the result"""
 
@@ -250,7 +250,7 @@ def remote(
 
     workspace = SyncedWorkspace.from_cwd(int_or_str_label(label))
     exit_code = workspace.execute_in_synced_env(
-        command, dry_run=dry_run, verbose=verbose, mirror=mirror, ports=ports, hot_reload=hot_reload
+        command, dry_run=dry_run, verbose=verbose, mirror=mirror, ports=ports, stream_changes=stream_changes
     )
     if exit_code != 0:
         click.secho(f"Remote command exited with {exit_code}", fg="yellow")

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -214,6 +214,14 @@ def remote_set(index: int):
     help="Enable local port forwarding. Pass value as <remote port>:<local port>. \
 If local port is not passed, the local port value would be set to <remote port> value by default",
 )
+@click.option(
+    "-h",
+    "--hot-reload",
+    default=False,
+    is_flag=True,
+    help="Continuously sync files from local to remote \
+     while executing the command",
+)
 @click.option("-l", "--label", help="use the host that has corresponding label for the remote execution")
 @click.argument("command", nargs=-1, required=True)
 @log_exceptions
@@ -225,6 +233,7 @@ def remote(
     e: bool,
     port_args: Optional[str],
     label: Optional[str],
+    hot_reload: bool,
 ):
     """Sync local workspace files to remote machine, execute the COMMAND and sync files back regardless of the result"""
 
@@ -240,7 +249,9 @@ def remote(
         sys.exit(1)
 
     workspace = SyncedWorkspace.from_cwd(int_or_str_label(label))
-    exit_code = workspace.execute_in_synced_env(command, dry_run=dry_run, verbose=verbose, mirror=mirror, ports=ports,)
+    exit_code = workspace.execute_in_synced_env(
+        command, dry_run=dry_run, verbose=verbose, mirror=mirror, ports=ports, hot_reload=hot_reload
+    )
     if exit_code != 0:
         click.secho(f"Remote command exited with {exit_code}", fg="yellow")
 

--- a/src/remote/stream_changes.py
+++ b/src/remote/stream_changes.py
@@ -1,0 +1,68 @@
+import time
+
+from contextlib import contextmanager
+from pathlib import Path
+from threading import Event, Thread
+from typing import Callable, List
+
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
+from watchdog.observers import Observer
+
+
+class SyncedWorkSpaceHandler(PatternMatchingEventHandler):
+    """Set has_changes when changes are notified by watchdog."""
+
+    def __init__(
+        self, has_changes: Event, ignore_patterns: List[str] = None,
+    ):
+        super().__init__(ignore_patterns=ignore_patterns)
+        self.has_changes = has_changes
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        """Sync local workspace when file changes"""
+        self.has_changes.set()
+
+
+class ProcessEvents(Thread):
+    """Executes a callback when a change is produced."""
+
+    def __init__(self, has_changes: Event, callback: Callable[[], None], settle_time: float = 1):
+        super().__init__()
+        self.do_run = True
+        self.settle_time = settle_time
+        self.has_changes = has_changes
+        self.callback = callback
+
+    def run(self):
+        while self.do_run:
+            time.sleep(self.settle_time)
+            if self.has_changes.is_set():
+                self.has_changes.clear()
+                self.callback()
+
+    def stop(self):
+        self.do_run = False
+
+
+@contextmanager
+def stream_local_changes(
+    local_root: Path, callback: Callable[[], None], settle_time: float = 1, ignore_patterns: List[str] = None
+) -> None:
+    """Sync local files whenever a change is made."""
+    has_changes = Event()
+    # Set up a worker thread to process the changes after the changes are settled as per the settle time.
+    worker = ProcessEvents(has_changes=has_changes, callback=callback, settle_time=settle_time)
+    # Start observing the local workspace.
+    observer = Observer()
+    observer.schedule(
+        SyncedWorkSpaceHandler(has_changes=has_changes, ignore_patterns=ignore_patterns), local_root, recursive=True
+    )
+    try:
+        worker.start()
+        observer.start()
+        yield
+    finally:
+        observer.stop()
+        worker.stop()
+        observer.join()
+        worker.join()

--- a/src/remote/stream_changes.py
+++ b/src/remote/stream_changes.py
@@ -36,7 +36,7 @@ class ProcessEvents(Thread):
     def run(self):
         while self.do_run:
             time.sleep(self.settle_time)
-            if self.has_changes.is_set():
+            if self.has_changes.is_set() and self.do_run:
                 self.has_changes.clear()
                 self.callback()
 

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -1,38 +1,18 @@
 import contextlib
 import logging
-import threading
-import time
 
-from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
-from threading import Event, Thread
 from typing import List, Optional, Tuple, Union
-
-from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
-from watchdog.observers import Observer
 
 from remote.exceptions import InvalidRemoteHostLabel
 
 from .configuration import RemoteConfig, SyncRules, WorkspaceConfig
 from .configuration.discovery import load_cwd_workspace_config
+from .stream_changes import stream_local_changes
 from .util import ForwardingOptions, Ssh, prepare_shell_command, rsync
 
 logger = logging.getLogger(__name__)
-
-
-class SyncedWorkSpaceHandler(PatternMatchingEventHandler):
-    """Set has_changes when changes are notified by watchdog."""
-
-    def __init__(
-        self, has_changes: Event, ignore_patterns: List[str] = None,
-    ):
-        PatternMatchingEventHandler.__init__(self, ignore_patterns=ignore_patterns)
-        self.has_changes = has_changes
-
-    def on_any_event(self, event: FileSystemEvent) -> None:
-        """Sync local workspace when file changes"""
-        self.has_changes.set()
 
 
 @dataclass
@@ -135,7 +115,7 @@ cd {relative_path}
         dry_run: bool = False,
         mirror: bool = False,
         ports: Optional[Tuple[int, int]] = None,
-        hot_reload: bool = False,
+        stream_changes: bool = False,
     ) -> int:
         """Execute a command remotely using ssh. Push the local files to remote location before that and
         pull them back after command was executed regardless of the result.
@@ -150,13 +130,13 @@ cd {relative_path}
         :param mirror: mirror local files remotely. It will remove ALL the remote files in the directory
                        that weren't synced from local workspace
         :param ports: A tuple of remote port,local port to enable local port forwarding
-        :param hot_reload: Continuously sync files from local to remote while executing the command
+        :param stream_changes: Continuously sync files from local to remote while executing the command
         :returns: an exit code of a remote process
         """
 
         self.push(dry_run=dry_run, verbose=verbose, mirror=mirror)
         exit_code = self.execute(
-            command, simple=simple, dry_run=dry_run, raise_on_error=False, ports=ports, hot_reload=hot_reload
+            command, simple=simple, dry_run=dry_run, raise_on_error=False, ports=ports, stream_changes=stream_changes
         )
         if exit_code != 0:
             logger.info(f"Remote command exited with {exit_code}")
@@ -170,7 +150,7 @@ cd {relative_path}
         dry_run: bool = False,
         raise_on_error: bool = True,
         ports: Optional[Tuple[int, int]] = None,
-        hot_reload: bool = False,
+        stream_changes: bool = False,
     ) -> int:
         """Execute a command remotely using ssh
 
@@ -180,7 +160,7 @@ cd {relative_path}
         :param dry_run: log the command to be executed but don't run it.
         :param raise_on_error: raise exception if error code was other than 0.
         :param ports: A tuple of remote port, local port to enable local port forwarding
-        :param hot_reload: Continuously sync files from local to remote while executing the command
+        :param stream_changes: Continuously sync files from local to remote while executing the command
 
         :returns: an exit code of a remote process
         """
@@ -190,7 +170,10 @@ cd {relative_path}
 
         port_forwarding = ForwardingOptions(remote_port=ports[0], local_port=ports[1]) if ports else None
         ssh = self.get_ssh(port_forwarding)
-        with self.hot_reload() if hot_reload else contextlib.nullcontext():
+
+        with stream_local_changes(
+            local_root=self.local_root, callback=self.push, settle_time=1
+        ) if stream_changes else contextlib.suppress():
             return ssh.execute(formatted_command, dry_run, raise_on_error)
 
     def push(self, info: bool = False, verbose: bool = False, dry_run: bool = False, mirror: bool = False) -> None:
@@ -264,34 +247,3 @@ cd {relative_path}
     def create_remote(self) -> None:
         """Remove remote directory"""
         self.execute(f"mkdir -p {self.remote.directory}", simple=True)
-
-    @contextmanager
-    def hot_reload(self, hot_reload_time: float = 1) -> None:
-        """Sync local files whenever a change is made."""
-        has_changes = Event()
-        # Set up a worker thread to process the changes after the changes are settled as per the hot reload time.
-        worker = Thread(target=self.process_events, args=(has_changes, hot_reload_time))
-        # Start observing the local workspace.
-        observer = Observer()
-        observer.schedule(SyncedWorkSpaceHandler(has_changes), self.local_root, recursive=True)
-        try:
-            worker.start()
-            observer.start()
-            yield
-        finally:
-            observer.stop()
-            worker.do_run = False
-            observer.join()
-            worker.join()
-
-    def process_events(self, has_changes: Event, hot_reload_time: float = 1) -> None:
-        """Process file system events."""
-        thread = threading.currentThread()
-        # The do_run attribute helps in gracefully stopping the thread.
-        while getattr(thread, "do_run", True):
-            time.sleep(hot_reload_time)
-            # Timeout after 1 second if there are no changes.
-            has_any_changes = has_changes.wait(timeout=1)
-            if has_any_changes:
-                has_changes.clear()
-                self.push()

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -130,7 +130,7 @@ cd {relative_path}
         :param mirror: mirror local files remotely. It will remove ALL the remote files in the directory
                        that weren't synced from local workspace
         :param ports: A tuple of remote port,local port to enable local port forwarding
-        :param stream_changes: Continuously sync files from local to remote while executing the command
+        :param stream_changes: Resync local changes if any while the command is being run remotely
         :returns: an exit code of a remote process
         """
 
@@ -160,7 +160,7 @@ cd {relative_path}
         :param dry_run: log the command to be executed but don't run it.
         :param raise_on_error: raise exception if error code was other than 0.
         :param ports: A tuple of remote port, local port to enable local port forwarding
-        :param stream_changes: Continuously sync files from local to remote while executing the command
+        :param stream_changes: Resync local changes if any while the command is being run remotely
 
         :returns: an exit code of a remote process
         """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from remote.configuration import RemoteConfig, WorkspaceConfig
+from remote.workspace import SyncedWorkspace
 
 
 @pytest.fixture
@@ -15,6 +16,14 @@ def workspace_config(tmp_path):
         RemoteConfig(host="test-host.example.com", directory=Path("remote/dir"), shell="sh", shell_options="")
     )
     return config
+
+
+@pytest.fixture
+def workspace(workspace_config):
+    workspace_config.ignores.pull.append("build")
+    working_dir = workspace_config.root / "foo" / "bar"
+    working_dir.mkdir(parents=True)
+    return SyncedWorkspace.from_config(workspace_config, working_dir)
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -972,10 +972,10 @@ echo test
 
 
 @patch("remote.util.subprocess.run")
-def test_live_reload(mock_run, tmp_workspace):
-    """Ensure the execution with live reload runs successfully"""
+def test_stream_changes(mock_run, tmp_workspace):
+    """Ensure the execution with stream changes runs successfully"""
     mock_run.return_value = Mock(returncode=0)
     runner = CliRunner()
     with cwd(tmp_workspace):
-        result = runner.invoke(entrypoints.remote, ["--hot-reload", "echo test"])
+        result = runner.invoke(entrypoints.remote, ["--stream-changes", "echo test"])
         assert result.exit_code == 0

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -969,3 +969,13 @@ echo test
             stdin=ANY,
             stdout=ANY,
         )
+
+
+@patch("remote.util.subprocess.run")
+def test_live_reload(mock_run, tmp_workspace):
+    """Ensure the execution with live reload runs successfully"""
+    mock_run.return_value = Mock(returncode=0)
+    runner = CliRunner()
+    with cwd(tmp_workspace):
+        result = runner.invoke(entrypoints.remote, ["--hot-reload", "echo test"])
+        assert result.exit_code == 0

--- a/test/test_stream_changes.py
+++ b/test/test_stream_changes.py
@@ -1,0 +1,43 @@
+from time import sleep
+from unittest.mock import ANY, MagicMock, patch
+
+from remote.stream_changes import stream_local_changes
+
+
+@patch("remote.util.subprocess.run")
+def test_stream_changes_when_event_triggered(mock_run, workspace):
+    """workspace pull is called when a file is created."""
+    mock_run.return_value = MagicMock(returncode=0)
+    with stream_local_changes(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
+        (workspace.local_root / "foo.txt").touch()
+        # Mock command execution behavior.
+        sleep(0.3)
+    mock_run.assert_called_once_with(
+        [
+            "rsync",
+            "-arlpmchz",
+            "--copy-unsafe-links",
+            "-e",
+            "ssh -Kq -o BatchMode=yes",
+            "--force",
+            "--delete",
+            "--rsync-path",
+            "mkdir -p remote/dir && rsync",
+            "--include-from",
+            ANY,
+            f"{workspace.local_root}/",
+            f"{workspace.remote.host}:{workspace.remote.directory}",
+        ],
+        stderr=ANY,
+        stdout=ANY,
+    )
+
+
+@patch("remote.util.subprocess.run")
+def test_stream_changes_when_no_event_triggered(mock_run, workspace):
+    """Local sources should not be synced as nothing changed."""
+    mock_run.return_value = MagicMock(returncode=0)
+    with stream_local_changes(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
+        # Mock command execution behavior.
+        sleep(0.3)
+    assert not mock_run.called

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from time import sleep
 from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
@@ -7,14 +6,6 @@ import pytest
 from remote.configuration import RemoteConfig
 from remote.exceptions import InvalidRemoteHostLabel
 from remote.workspace import SyncedWorkspace
-
-
-@pytest.fixture
-def workspace(workspace_config):
-    workspace_config.ignores.pull.append("build")
-    working_dir = workspace_config.root / "foo" / "bar"
-    working_dir.mkdir(parents=True)
-    return SyncedWorkspace.from_config(workspace_config, working_dir)
 
 
 def test_create_workspace(workspace_config):
@@ -157,45 +148,6 @@ def test_pull_with_subdir(mock_run, workspace):
         stderr=ANY,
         stdout=ANY,
     )
-
-
-@patch("remote.util.subprocess.run")
-def test_sync_continuously(mock_run, workspace):
-    """workspace pull is called when a file is created."""
-    mock_run.return_value = MagicMock(returncode=0)
-    with workspace.hot_reload(0.01):
-        (workspace.local_root / "foo.txt").touch()
-        # Mock command execution behavior.
-        sleep(0.3)
-    mock_run.assert_called_once_with(
-        [
-            "rsync",
-            "-arlpmchz",
-            "--copy-unsafe-links",
-            "-e",
-            "ssh -Kq -o BatchMode=yes",
-            "--force",
-            "--delete",
-            "--rsync-path",
-            "mkdir -p remote/dir && rsync",
-            "--include-from",
-            ANY,
-            f"{workspace.local_root}/",
-            f"{workspace.remote.host}:{workspace.remote.directory}",
-        ],
-        stderr=ANY,
-        stdout=ANY,
-    )
-
-
-@patch("remote.util.subprocess.run")
-def test_sync_continuously_when_no_events_triggered(mock_run, workspace):
-    """Local sources should not be synced as nothing changed."""
-    mock_run.return_value = MagicMock(returncode=0)
-    with workspace.hot_reload(0.01):
-        # Mock command execution behavior.
-        sleep(0.3)
-    assert not mock_run.called
 
 
 @patch("remote.util.subprocess.run")


### PR DESCRIPTION
Developers can now sync files from local to remote during executing a command remotely.

This feature would help running long-running tasks like running a server that has a feature of hot reloads. While running the server remotely developers can now pass `--stream-changes` flag to enable local file syncing till the remote command is executing.

Implementation:
Internally this change uses watchdog to record file-level changes and run rsync in the background. 
Currently, the change does not configure ignore patterns and vcs ignores when watching over the directory as the watchdog uses fnmatch patterns which is incompatible with rsync and .gitignore patterns. This optimization can be taken up later if required.