### PR TITLE
Rename stream_local_changes to execute_on_file_change

### DIFF
--- a/src/remote/file_changes.py
+++ b/src/remote/file_changes.py
@@ -45,10 +45,10 @@ class ProcessEvents(Thread):
 
 
 @contextmanager
-def stream_local_changes(
+def execute_on_file_change(
     local_root: Path, callback: Callable[[], None], settle_time: float = 1, ignore_patterns: List[str] = None
 ) -> None:
-    """Sync local files whenever a change is made."""
+    """Execute callback whenever files change."""
     has_changes = Event()
     # Set up a worker thread to process the changes after the changes are settled as per the settle time.
     worker = ProcessEvents(has_changes=has_changes, callback=callback, settle_time=settle_time)

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -9,7 +9,7 @@ from remote.exceptions import InvalidRemoteHostLabel
 
 from .configuration import RemoteConfig, SyncRules, WorkspaceConfig
 from .configuration.discovery import load_cwd_workspace_config
-from .stream_changes import stream_local_changes
+from .file_changes import execute_on_file_change
 from .util import ForwardingOptions, Ssh, prepare_shell_command, rsync
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,7 @@ cd {relative_path}
         port_forwarding = ForwardingOptions(remote_port=ports[0], local_port=ports[1]) if ports else None
         ssh = self.get_ssh(port_forwarding)
 
-        with stream_local_changes(
+        with execute_on_file_change(
             local_root=self.local_root, callback=self.push, settle_time=1
         ) if stream_changes else contextlib.suppress():
             return ssh.execute(formatted_command, dry_run, raise_on_error)

--- a/test/test_file_changes.py
+++ b/test/test_file_changes.py
@@ -1,14 +1,14 @@
 from time import sleep
 from unittest.mock import ANY, MagicMock, patch
 
-from remote.stream_changes import stream_local_changes
+from remote.file_changes import execute_on_file_change
 
 
 @patch("remote.util.subprocess.run")
 def test_stream_changes_when_event_triggered(mock_run, workspace):
     """workspace pull is called when a file is created."""
     mock_run.return_value = MagicMock(returncode=0)
-    with stream_local_changes(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
+    with execute_on_file_change(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
         (workspace.local_root / "foo.txt").touch()
         # Mock command execution behavior.
         sleep(0.3)
@@ -37,7 +37,7 @@ def test_stream_changes_when_event_triggered(mock_run, workspace):
 def test_stream_changes_when_no_event_triggered(mock_run, workspace):
     """Local sources should not be synced as nothing changed."""
     mock_run.return_value = MagicMock(returncode=0)
-    with stream_local_changes(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
+    with execute_on_file_change(local_root=workspace.local_root, callback=workspace.push, settle_time=0.01):
         # Mock command execution behavior.
         sleep(0.3)
     assert not mock_run.called


### PR DESCRIPTION
Since a callback is passed stream_local_changes does not make sense as it has the action in the variable name. 