### PR TITLE
Add a way to programmatically set env variables for remote executions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ multi_line_output = 3
 lines_between_types = 1
 include_trailing_comma = true
 use_parentheses = true
-not_skip = __init__.py
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [tool:pytest]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,12 +3,12 @@ attrs==19.3.0
 black==19.10b0
 click==7.1.2
 coverage==5.1
-flake8==3.8.1
+flake8==3.8.3
 importlib-metadata==1.6.0
-isort==4.3.21
+isort==5.2.2
 mccabe==0.6.1
 more-itertools==8.2.0
-mypy==0.770
+mypy==0.782
 mypy-extensions==0.4.3
 packaging==20.3
 pathspec==0.8.0
@@ -21,7 +21,7 @@ pytest==5.4.2
 pytest-cov==2.8.1
 regex==2020.5.7
 six==1.14.0
-toml==0.10.0
+toml==0.10.1
 typed-ast==1.4.1
 typing-extensions==3.7.4.2
 wcwidth==0.1.9


### PR DESCRIPTION
This PR introduces a possibility to set some env variables for the remote execution programmatically, this might be required for API consumers in the near future

It also updates some code-quality dependencies versions