### PR TITLE
Add --tunnel argument to remote-quick entrypoint

### DIFF
--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -337,15 +337,28 @@ def remote(
 
 
 @click.command(context_settings=EXECUTION_CONTEXT_SETTINGS)
+@click.option(
+    "-t",
+    "--tunnel",
+    "port_args",
+    type=str,
+    multiple=True,
+    help="Enable local port forwarding. Pass value as <remote port>:<local port>. \
+If local port is not passed, the local port value would be set to <remote port> value by default",
+)
 @click.option("-l", "--label", help="use the host that has corresponding label for the remote execution")
 @click.argument("command", nargs=-1, required=True)
 @log_exceptions
-def remote_quick(command: List[str], label: Optional[str]):
-    """Execute the COMMAND remotely"""
+def remote_quick(
+    command: List[str], port_args: List[str], label: Optional[str],
+):
+    """Execute the COMMAND remotely, without syncing any files"""
     check_command(command)
 
+    ports = [ForwardingOption.from_string(port_arg) for port_arg in port_args]
+
     workspace = SyncedWorkspace.from_cwd(int_or_str_label(label))
-    code = workspace.execute(command, raise_on_error=False)
+    code = workspace.execute(command, ports=ports, raise_on_error=False)
     sys.exit(code)
 
 

--- a/test/test_entrypoints.py
+++ b/test/test_entrypoints.py
@@ -1150,14 +1150,17 @@ def test_remote_port_forwarding_user_input_error(
     "port_value, expected_port_forwarding, expected_exit_code",
     [("5000", "5000:localhost:5000", 0), ("5000:5005", "5005:localhost:5000", 0)],
 )
+@pytest.mark.parametrize(
+    "entrypoint", [entrypoints.remote, entrypoints.remote_quick], ids=["remote", "remote-quick"],
+)
 @patch("remote.util.subprocess.run")
 def test_remote_port_forwarding_successful(
-    mock_run, tmp_workspace, port_value, expected_port_forwarding, expected_exit_code
+    mock_run, tmp_workspace, port_value, expected_port_forwarding, expected_exit_code, entrypoint,
 ):
     mock_run.return_value = Mock(returncode=0)
     runner = CliRunner()
     with cwd(tmp_workspace):
-        result = runner.invoke(entrypoints.remote, ["-t", port_value, "echo test"])
+        result = runner.invoke(entrypoint, ["-t", port_value, "echo test"])
         assert result.exit_code == expected_exit_code
         mock_run.assert_any_call(
             [


### PR DESCRIPTION
Useful to have when running live documentation or jupyter notebooks