### PR TITLE
Switch the order of api-provided env and remoteenv application

### DIFF
--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -124,11 +124,11 @@ class SyncedWorkspace:
 
         return f"""\
 cd {self.remote.directory}
-if [ -f .remoteenv ]; then
+{env_variables}if [ -f .remoteenv ]; then
   source .remoteenv
 fi
 cd {relative_path}
-{env_variables}{command}
+{command}
 """
 
     def execute_in_synced_env(

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -352,12 +352,12 @@ def test_execute_with_custom_env(mock_run, workspace):
             workspace.remote.host,
             """\
 cd remote/dir
+export OTHER_VAR=meow
+export TEST_VAR=test
 if [ -f .remoteenv ]; then
   source .remoteenv
 fi
 cd foo/bar
-export OTHER_VAR=meow
-export TEST_VAR=test
 echo 'Hello World!'
 """,
         ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -23,6 +23,6 @@ regex==2020.5.7
 six==1.14.0
 toml==0.10.1
 typed-ast==1.4.1
-typing-extensions==3.7.4.2
+typing-extensions==3.7.4.3
 wcwidth==0.1.9
 zipp==3.1.0


### PR DESCRIPTION
We usually want the user to be able to overwrite or extend the env variables we put in the environment using workspace API. To do it, we switch the order of these env variables application