### PR TITLE
attempt to fix shiv implementation error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v1
           with:
-            python-version: 3.7
+            python-version: 3.8
         - name: Install shiv
           run: pip install shiv
         - name: Build executable and tgz


### PR DESCRIPTION
Job `build shiv implementation` is failing due to the following error
LookupError: https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz (from https://pypi.org/simple/importlib-metadata/) (requires-python:>=3.7) is already being built: importlib-metadata from https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz (from click>=7.1.1->remote-exec==1.12.0)

This PR is an attempt to fix it.