### PR TITLE
toml: add support for `cmd_prefix` in [[hosts]]

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ include_vcs_ignore_patterns = true
      methods. We recommend disabling it if the ssh connection to the host hangs for some time during establishing.
    * `default` (optional, defaults to `false`) - `true` if this host should be used by default
    * `label` (optional) - a text label that later can be used to identify the host when running the `remote` CLI.
+   * `cmd_prefix` (optional) - a string which is prefixed to all commands executed via the `remote` CLI. The prefix is **not** shell escaped.
 
 3. `[push]`, `[pull]`, and `[both]` blocks control what files are synced from local to a remote machine and back
    before and after the execution. These blocks are used when the workspace configuration doesn't overwrite them.
@@ -226,6 +227,7 @@ host = "linux-host.example.com"
 directory = ".remotes/workspace"
 label = "linux"
 supports_gssapi_auth = true
+cmd_prefix = "nice -n5"
 
 [[hosts]]
 host = "macos-host.example.com"

--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -20,6 +20,8 @@ class RemoteConfig:
     supports_gssapi: bool = True
     # Add label to identify remote
     label: Optional[str] = None
+    # prepended to every command, will not be shell escaped
+    cmd_prefix: Optional[str] = None
     # A SSH port, if it differs from default
     port: Optional[int] = None
 
@@ -101,6 +103,7 @@ class WorkspaceConfig:
         shell: Optional[str] = None,
         shell_options: Optional[str] = None,
         label: Optional[str] = None,
+        cmd_prefix: Optional[str] = None,
         port: Optional[int] = None,
     ) -> Tuple[bool, int]:
         remote_config = RemoteConfig(
@@ -109,6 +112,7 @@ class WorkspaceConfig:
             shell=shell or "sh",
             shell_options=shell_options or "",
             label=label,
+            cmd_prefix=cmd_prefix,
             port=port,
         )
         for num, cfg in enumerate(self.configurations):

--- a/src/remote/configuration/toml.py
+++ b/src/remote/configuration/toml.py
@@ -34,6 +34,7 @@ class ConnectionConfig(ConfigModel):
     directory: Optional[Path] = None
     default: bool = False
     label: Optional[str] = None
+    cmd_prefix: Optional[str] = None
     # True if remote host supports gssapi-* auth methods. Should de disable if it isn't because it might result
     # in connection hanging for some time before establishing
     # The default is True for backward compatibility, we might reconsider this in next major version
@@ -286,6 +287,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     directory=connection.directory or self._generate_remote_directory_from_path(workspace_root),
                     supports_gssapi=connection.supports_gssapi_auth,
                     label=connection.label,
+                    cmd_prefix=connection.cmd_prefix,
                     port=connection.port,
                 )
             )
@@ -326,6 +328,7 @@ class TomlConfigurationMedium(ConfigurationMedium):
                     default=num == config.default_configuration,
                     supports_gssapi_auth=connection.supports_gssapi,
                     label=connection.label,
+                    cmd_prefix=connection.cmd_prefix,
                     port=connection.port,
                 )
             )

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -58,7 +58,7 @@ class SyncedWorkspace:
         working_dir = working_dir.relative_to(config.root)
         if remote_host_id is None:
             index = config.default_configuration
-        elif type(remote_host_id) == str:
+        elif isinstance(remote_host_id, str):
             index = next(
                 (
                     index
@@ -120,6 +120,9 @@ class SyncedWorkspace:
         env_variables = "\n".join([f"export {shell_quote(k)}={shell_quote(env[k])}" for k in sorted(env.keys())])
         if env_variables:
             env_variables += "\n"
+
+        if self.remote.cmd_prefix is not None:
+            command = f"{self.remote.cmd_prefix} {command}"
 
         return f"""\
 cd {shell_quote(self.remote.directory)}

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -202,9 +202,9 @@ include = ["configs/global"]
         hosts=[
             ConnectionConfig(host="test-host.example.com", directory=".remotes/workspace", default=False),
             ConnectionConfig(
-                host="other-host.example.com", 
-                directory=".remotes/other-workspace", 
-                default=True, 
+                host="other-host.example.com",
+                directory=".remotes/other-workspace",
+                default=True,
                 cmd_prefix="nice -n5"
             ),
         ],

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -201,7 +201,12 @@ include = ["configs/global"]
     assert config == LocalConfig(
         hosts=[
             ConnectionConfig(host="test-host.example.com", directory=".remotes/workspace", default=False),
-            ConnectionConfig(host="other-host.example.com", directory=".remotes/other-workspace", default=True, cmd_prefix="nice -n5"),
+            ConnectionConfig(
+                host="other-host.example.com", 
+                directory=".remotes/other-workspace", 
+                default=True, 
+                cmd_prefix="nice -n5"
+            ),
         ],
         push=SyncRulesConfig(exclude=["env", ".git"], include=["env"]),
         pull=SyncRulesConfig(exclude=["src/generated"]),

--- a/test/configuration/test_toml.py
+++ b/test/configuration/test_toml.py
@@ -91,6 +91,7 @@ Invalid value in configuration file /root/.config/remote/defaults.toml:
 [[hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
+cmd_prefix = "nice -n5"
 default = true
 
 [push]
@@ -180,6 +181,7 @@ directory = ".remotes/workspace"
 [[hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
+cmd_prefix = "nice -n5"
 default = true
 
 [push]
@@ -199,7 +201,7 @@ include = ["configs/global"]
     assert config == LocalConfig(
         hosts=[
             ConnectionConfig(host="test-host.example.com", directory=".remotes/workspace", default=False),
-            ConnectionConfig(host="other-host.example.com", directory=".remotes/other-workspace", default=True),
+            ConnectionConfig(host="other-host.example.com", directory=".remotes/other-workspace", default=True, cmd_prefix="nice -n5"),
         ],
         push=SyncRulesConfig(exclude=["env", ".git"], include=["env"]),
         pull=SyncRulesConfig(exclude=["src/generated"]),
@@ -253,10 +255,12 @@ def test_load_local_config_no_file(tmp_path):
 [[hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
+cmd_prefix = "nice -n5"
 
 [[extends.hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
+cmd_prefix = "nice -n5"
 """,
             "Following fields are specified in for overwrite and extend in /root/.remote.toml file: hosts.",
         ),
@@ -269,6 +273,7 @@ remote_root = "my-remotes"
 [[extends.hosts]]
 host = "other-host.example.com"
 directory = ".remotes/other-workspace"
+cmd_prefix = "nice -n5"
 """,
             """\
 Invalid value in configuration file /root/.remote.toml:
@@ -829,6 +834,7 @@ def test_medium_is_workspace_root(mock_home):
                         directory=Path(".remotes/other-workspace"),
                         supports_gssapi=False,
                         label="bar",
+                        cmd_prefix="nice -n5",
                     ),
                 ],
                 default_configuration=1,
@@ -847,6 +853,7 @@ host = "other-host.example.com"
 directory = ".remotes/other-workspace"
 default = true
 label = "bar"
+cmd_prefix = "nice -n5"
 supports_gssapi_auth = false
 
 [push]


### PR DESCRIPTION
Fixes #49, does not add support for `cmd_prefix` in `[general]`, only in `[[hosts]]`.
